### PR TITLE
Use Homebrew Core formula for PowerShell on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The easiest way to install PowerShell is via [Homebrew](https://brew.sh/):
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Install PowerShell
-brew install powershell/tap/powershell
+brew install powershell
 ```
 
 Alternative: Download the `.pkg` installer from [PowerShell releases](https://github.com/PowerShell/PowerShell/releases/latest).


### PR DESCRIPTION
The powershell/tap/powershell tap is broken and throws: "Calling `depends_on macos: :high_sierra` is disabled!"

See: https://github.com/PowerShell/Homebrew-Tap/issues/1339