### PR TITLE
Document Docker usage in README (closes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ pwsh ./Shield-Optimizer.ps1
 
 ### Linux (Docker)
 
+> *Should work, but not verified end-to-end.* Based on the workflow @shawly reported in [#9](https://github.com/bryanroscoe/shield_optimizer/issues/9).
+
 If you'd rather not install PowerShell on your host, you can run the script inside Microsoft's official PowerShell container. `--network host` is required so the script can scan your LAN for devices, and `iproute2` is needed inside the container for the auto-discovery scan.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ sudo apt-get install -y powershell
 pwsh ./Shield-Optimizer.ps1
 ```
 
+### Linux (Docker)
+
+If you'd rather not install PowerShell on your host, you can run the script inside Microsoft's official PowerShell container. `--network host` is required so the script can scan your LAN for devices, and `iproute2` is needed inside the container for the auto-discovery scan.
+
+```bash
+# Start an interactive PowerShell container on the host network
+docker run -it --rm --network host mcr.microsoft.com/powershell:latest
+
+# Inside the container:
+apt-get update && apt-get install -y iproute2
+Invoke-WebRequest -Uri https://github.com/bryanroscoe/shield_optimizer/raw/refs/heads/main/Shield-Optimizer.ps1 -OutFile Shield-Optimizer.ps1
+./Shield-Optimizer.ps1
+```
+
+> **Note:** `--network host` only works on native Linux. On Docker Desktop for macOS/Windows, auto-discovery won't see your LAN — install PowerShell natively (see above) or use the script's **Connect IP** option to enter your device's IP manually.
+
 ## Download
 
 **Option 1: Download from Releases (Recommended)**


### PR DESCRIPTION
Adds an Installation subsection for running the script inside Microsoft's official PowerShell container on Linux, using the approach @shawly verified in the issue thread:

- `--network host` so the LAN scan works
- `iproute2` installed inside the container for auto-discovery

Also calls out the Docker Desktop limitation on macOS/Windows where host networking isn't available, directing those users to native PowerShell install or manual Connect IP.

Closes #9.