### PR TITLE
Always prefix digit shortcuts in Read-Menu

### DIFF
--- a/Shield-Optimizer.ps1
+++ b/Shield-Optimizer.ps1
@@ -1759,17 +1759,22 @@ function Read-Menu ($Title, $Options, $Descriptions, $DefaultIndex=0, $StaticSta
             $shortcutMap[$char] = $i
         }
 
-        # Pre-compute display text with embedded shortcut
+        # Pre-compute display text with embedded shortcut.
+        # Digit shortcuts always prefix — inlining them inside text that contains
+        # other digits (e.g. IP addresses) is ambiguous. Letter shortcuts inline
+        # when the character appears, otherwise fall back to a prefix.
         $shortcut = $shortcutDisplay[$i]
         $optText = $Options[$i]
         $foundPos = -1
-        $inBracket = $false
-        for ($c = 0; $c -lt $optText.Length; $c++) {
-            if ($optText[$c] -eq '[') { $inBracket = $true }
-            elseif ($optText[$c] -eq ']') { $inBracket = $false }
-            elseif (-not $inBracket -and $optText[$c].ToString().ToUpper() -eq $shortcut.ToUpper()) {
-                $foundPos = $c
-                break
+        if ($shortcut -notmatch '^\d$') {
+            $inBracket = $false
+            for ($c = 0; $c -lt $optText.Length; $c++) {
+                if ($optText[$c] -eq '[') { $inBracket = $true }
+                elseif ($optText[$c] -eq ']') { $inBracket = $false }
+                elseif (-not $inBracket -and $optText[$c].ToString().ToUpper() -eq $shortcut.ToUpper()) {
+                    $foundPos = $c
+                    break
+                }
             }
         }
         if ($foundPos -ge 0) {


### PR DESCRIPTION
Fixes a visual inconsistency in the device-list menu (and any other menu using digit shortcuts) where the keystroke indicator could land inside an IP octet.

For row N with shortcut digit \`N\`, the previous logic searched the option text for the first occurrence of \`N\` and bracketed it inline. For an IP like \`192.168.42.196\` with shortcut \`2\`, that produced \`19[2].168.42.196\` — bracketing an arbitrary octet character. If the digit didn't appear at all (e.g. shortcut \`3\` against \`192.168.42.25\`), the code fell back to a clean \`[3] <text>\` prefix, so different rows of the same menu rendered inconsistently.

This change skips the inline search whenever the shortcut is a digit and always uses the prefix form. Letter shortcuts (\`[S]can\`, \`[C]onnect\`, etc.) keep the inline behavior since callers pick those characters to line up with meaningful content.

### Side effects
- AT4K Launcher option (shortcut \`4\`) goes from \`AT[4]K Launcher\` to \`[4] AT4K Launcher\`.
- Process-limit options (\`At Most 1\`, \`At Most 2\`, …) go from \`At Most [1]\` to \`[1] At Most 1\`. Slightly redundant text, but consistent.

### Verification
- \`make lint\` — Syntax OK
- \`make test\` — 97 passed / 4 skipped / 0 failed
- Visual behavior on a real device not exercised; logic-only change to display string assembly.