### PR TITLE
Use role API when setting the default launcher

### DIFF
--- a/Shield-Optimizer.ps1
+++ b/Shield-Optimizer.ps1
@@ -2698,11 +2698,18 @@ function Get-LauncherActivity ($Target, $PackageName) {
     return $null
 }
 
-# Set the default launcher using cmd package set-home-activity
+# Set the default launcher.
+# Tries the modern role API first (`cmd role add-role-holder` — Android 10+ canonical
+# path, the only one that survives reboot reliably on Android 11+), then falls
+# back to the legacy `cmd package set-home-activity` for older builds.
 function Set-DefaultLauncher ($Target, $PackageName) {
+    if (Set-HomeRoleHolder -Target $Target -Package $PackageName) {
+        return $true
+    }
+
+    # Legacy fallback: needs an explicit activity component
     $activity = Get-LauncherActivity -Target $Target -PackageName $PackageName
     if (-not $activity) {
-        # Try common activity names as fallback
         $commonActivities = @(
             "$PackageName/.MainActivity",
             "$PackageName/.Main",


### PR DESCRIPTION
\`Set-DefaultLauncher\` only called \`cmd package set-home-activity\`, which is the legacy Android API. On Android 10+ the canonical mechanism is the role API (\`cmd role add-role-holder android.app.role.HOME <pkg>\`); on Android 11+ the legacy command frequently no-ops silently. Reproduced on a real Shield running Android 11 — wizard reported "Could not set default programmatically" even after Projectivy was installed and the user clicked through the wizard.

The codebase already has \`Set-HomeRoleHolder\` (used by \`Disable-AllStockLaunchers\`). Try it first in \`Set-DefaultLauncher\`; fall through to the legacy command + activity-name fallbacks only if the role API rejects the package.

### Verification
- \`make lint\` — Syntax OK
- \`make test\` — 121 passed / 4 skipped / 0 failed
- On-device verification pending — open this PR for the user to retry the wizard.