### PR TITLE
Clarify channel-breaking warnings on bloat list

### DIFF
--- a/Shield-Optimizer.ps1
+++ b/Shield-Optimizer.ps1
@@ -290,7 +290,7 @@ $Script:CommonAppList = @(
     @{ Package = "com.google.android.tv.remote.service"; Name = "Virtual Remote Keyboard"; Method = "DISABLE"; Risk = "Medium"
        OptimizeDescription = "Disables virtual remote keyboard that auto-activates."; RestoreDescription = "Restores virtual remote keyboard functionality."; DefaultOptimize = "N"; DefaultRestore = "Y" }
     @{ Package = "com.android.providers.tv"; Name = "Live Channels Provider"; Method = "DISABLE"; Risk = "High Risk"
-       OptimizeDescription = "Breaks Pandora and apps using Live Channels API."; RestoreDescription = "Restores Live Channels support."; DefaultOptimize = "N"; DefaultRestore = "Y" }
+       OptimizeDescription = "Breaks Watch Next / Continue Watching channels for Apple TV, Netflix, Disney+, etc. Also breaks Pandora and the Live Channels app."; RestoreDescription = "Restores Watch Next channel support and Live Channels."; DefaultOptimize = "N"; DefaultRestore = "Y" }
 
     # --- HIGH RISK: May break features ---
     @{ Package = "com.google.android.katniss"; Name = "Google Assistant"; Method = "DISABLE"; Risk = "High Risk"
@@ -317,7 +317,7 @@ $Script:ShieldAppList = @(
     @{ Package = "com.nvidia.feedback"; Name = "Nvidia Feedback"; Method = "DISABLE"; Risk = "Safe"
        OptimizeDescription = "Stops Nvidia feedback collection."; RestoreDescription = "Restores Nvidia feedback."; DefaultOptimize = "Y"; DefaultRestore = "Y" }
     @{ Package = "com.google.android.tvrecommendations"; Name = "Sponsored Content"; Method = "DISABLE"; Risk = "Safe"
-       OptimizeDescription = "Removes 'Sponsored' rows from home."; RestoreDescription = "Restores sponsored content rows."; DefaultOptimize = "Y"; DefaultRestore = "Y" }
+       OptimizeDescription = "Removes Sponsored / Top Picks rows on the stock Google TV home. Also removes the home-screen Watch Next rows that surface Apple TV / Netflix Continue Watching. No effect if you've switched to a custom launcher."; RestoreDescription = "Restores sponsored and Watch Next rows on stock launcher."; DefaultOptimize = "Y"; DefaultRestore = "Y" }
 
     # --- MEDIUM: Shield-specific services ---
     @{ Package = "com.nvidia.osc"; Name = "Nvidia OSC"; Method = "DISABLE"; Risk = "Medium"
@@ -350,7 +350,7 @@ $Script:GoogleTVAppList = @(
     @{ Package = "com.walmart.otto"; Name = "Walmart App"; Method = "UNINSTALL"; Risk = "Safe"
        OptimizeDescription = "Removes Walmart bloatware."; RestoreDescription = "Restores Walmart app."; DefaultOptimize = "Y"; DefaultRestore = "Y" }
     @{ Package = "com.google.android.leanbacklauncher.recommendations"; Name = "Home Recommendations"; Method = "DISABLE"; Risk = "Safe"
-       OptimizeDescription = "Removes extra recommendation rows."; RestoreDescription = "Restores home recommendations."; DefaultOptimize = "Y"; DefaultRestore = "Y" }
+       OptimizeDescription = "Removes extra recommendation rows (older Android TV launcher only). No effect on custom or Google TV launchers."; RestoreDescription = "Restores home recommendations."; DefaultOptimize = "Y"; DefaultRestore = "Y" }
 
     # --- MEDIUM: Setup/calibration tools ---
     @{ Package = "com.google.android.tungsten.overscan"; Name = "Overscan Calibrator"; Method = "DISABLE"; Risk = "Medium"


### PR DESCRIPTION
Wording-only fix surfacing the *actual* cost of disabling three packages.

### Background
On a real Shield I found \`com.android.providers.tv\` disabled, which broke Apple TV's "Up Next" / "Continue Watching" channel — because the TvProvider is the system content provider where Apple TV / Netflix / Disney+ / etc. *all* publish their Watch Next entries. The user opted in to disabling it because the existing description only mentioned **Pandora** and the **Live Channels API** — not the much more user-visible cost of breaking app channels.

### Changes
- **\`com.android.providers.tv\`**: description now leads with "Watch Next / Continue Watching channels for Apple TV, Netflix, Disney+, etc." Pandora and Live Channels remain mentioned. Risk stays High Risk; default stays \`N\`.
- **\`com.google.android.tvrecommendations\`**: clarifies the disable removes *both* Sponsored rows *and* the home-screen Watch Next rows on the stock launcher, and that it's a no-op on third-party launchers (Projectivy/etc.).
- **\`com.google.android.leanbacklauncher.recommendations\`**: notes it only applies to the older Leanback launcher.

### Verification
- \`make lint\` — Syntax OK
- \`make test\` — 121 passed / 4 skipped / 0 failed
- No behavioral change.