### PR TITLE
Bump GitHub Actions to v5 to fix Windows checkout flakiness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Pester
         shell: pwsh
@@ -55,7 +55,7 @@ jobs:
           }
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: test-results-${{ matrix.os }}
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check PowerShell syntax
         shell: pwsh


### PR DESCRIPTION
### Root cause

The Tests workflow on main went red after PR #20 merged. Looking at the failed run for commit \`46cf06c\`, the failure is **not in our Pester tests** — it's in \`actions/checkout@v4\` itself on the windows-latest runner:

\`\`\`
fatal: Cannot prompt because user interactivity has been disabled.
fatal: could not read Username for 'https://github.com': terminal prompts disabled
\`\`\`

That's a known transient on the Windows runner image when checkout@v4 (Node.js 20) hits a particular auth state during \`git fetch\`. The same CI run produced GitHub's deprecation warning that Node 20 actions are flipping to Node 24 by default in June 2026 and being removed in September 2026.

### Fix

Bump both pinned actions in \`.github/workflows/tests.yml\` to v5 (Node 24):

- \`actions/checkout@v4\` → \`@v5\` (both job blocks)
- \`actions/upload-artifact@v4\` → \`@v5\`

### Verification

- Local \`make test\` (current main + this branch): **121 passed / 4 skipped / 0 failed** — the code was fine all along; the CI runner was the failure surface.
- CI will run on this PR (the workflow triggers on changes under \`.github/workflows/\`) — that's the actual check that matters here.
- Future deprecation noise from Node 20 → 24 is also resolved by the same bump.

Workflow-file-only change. No code, no test changes.