### PR TITLE
Light theme + Light/Dark/Auto toggle (fixes #26)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -17,6 +17,19 @@ When you add a new section, put it at the top; older releases go below.
 
 ---
 
+## v2-0.1.0-beta.5
+
+### Fixed
+
+- **Light mode is now readable, and you can pick a theme.** On Linux/macOS in
+  light appearance, the cards and text kept dark-mode colors against a light
+  page, making text nearly invisible (#26). The whole UI is now theme-aware via
+  CSS variables, with a proper light palette. A **Light / Dark / Auto** toggle
+  in the header lets you override the system appearance (Auto follows the OS).
+  Dark mode is unchanged.
+
+---
+
 ## v2-0.1.0-beta.4
 
 ### Fixed

--- a/v2/src/app.html
+++ b/v2/src/app.html
@@ -5,6 +5,15 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Shield Optimizer</title>
+    <script>
+      // Apply the saved theme before first paint to avoid a flash of the
+      // wrong colors. Mirrors $lib/theme.ts; "system" leaves no attribute.
+      try {
+        var t = localStorage.getItem("shieldopt.theme");
+        if (t === "light" || t === "dark")
+          document.documentElement.setAttribute("data-theme", t);
+      } catch (e) {}
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/v2/src/lib/theme.ts
+++ b/v2/src/lib/theme.ts
@@ -1,0 +1,35 @@
+// Theme preference: Light / Dark / System (follow OS).
+//
+// The actual colors live in CSS variables in +layout.svelte. This just drives
+// a `data-theme` attribute on <html>:
+//   - "system" → no attribute; CSS falls back to `prefers-color-scheme`
+//   - "light" / "dark" → explicit override regardless of OS
+// The initial value is also applied pre-paint by an inline script in app.html
+// to avoid a flash of the wrong theme on load.
+
+export type ThemePref = "system" | "light" | "dark";
+
+const KEY = "shieldopt.theme";
+
+export function getThemePref(): ThemePref {
+  if (typeof localStorage === "undefined") return "system";
+  const v = localStorage.getItem(KEY);
+  return v === "light" || v === "dark" ? v : "system";
+}
+
+export function applyTheme(pref: ThemePref): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (pref === "system") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", pref);
+  }
+}
+
+export function setThemePref(pref: ThemePref): void {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(KEY, pref);
+  }
+  applyTheme(pref);
+}

--- a/v2/src/routes/+layout.svelte
+++ b/v2/src/routes/+layout.svelte
@@ -1,6 +1,25 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import { page } from "$app/stores";
+  import { getThemePref, setThemePref, type ThemePref } from "$lib/theme";
+
   let { children } = $props();
+
+  let theme = $state<ThemePref>("system");
+  onMount(() => {
+    theme = getThemePref();
+  });
+
+  function pickTheme(pref: ThemePref) {
+    theme = pref;
+    setThemePref(pref);
+  }
+
+  const THEMES: { id: ThemePref; label: string; title: string }[] = [
+    { id: "system", label: "Auto", title: "Follow the system appearance" },
+    { id: "light", label: "Light", title: "Always light" },
+    { id: "dark", label: "Dark", title: "Always dark" },
+  ];
 </script>
 
 <div class="app">
@@ -10,12 +29,26 @@
       <span class="title">Shield Optimizer</span>
       <span class="version">v2</span>
     </div>
-    <nav>
-      <a href="/" class:active={$page.url.pathname === "/"}>Devices</a>
-      <a href="/snapshots" class:active={$page.url.pathname.startsWith("/snapshots")}>
-        Snapshots
-      </a>
-    </nav>
+    <div class="header-right">
+      <nav>
+        <a href="/" class:active={$page.url.pathname === "/"}>Devices</a>
+        <a href="/snapshots" class:active={$page.url.pathname.startsWith("/snapshots")}>
+          Snapshots
+        </a>
+      </nav>
+      <div class="theme-toggle" role="group" aria-label="Theme">
+        {#each THEMES as t (t.id)}
+          <button
+            class:active={theme === t.id}
+            title={t.title}
+            aria-pressed={theme === t.id}
+            onclick={() => pickTheme(t.id)}
+          >
+            {t.label}
+          </button>
+        {/each}
+      </div>
+    </div>
   </header>
   <main>
     {@render children?.()}
@@ -26,34 +59,114 @@
 </div>
 
 <style>
+  /* Semantic color tokens. Dark is the default (in :root); light values are
+     applied either by an explicit data-theme="light" or, when no preference is
+     set, by the OS via prefers-color-scheme. Dark values are unchanged from the
+     original design — only light values are new. */
   :global(:root) {
     color-scheme: dark;
     --bg-page: #0e1116;
-    --bg-chrome: #161b22;
+    --bg-surface: #161b22;
+    --bg-surface-2: #1c2128;
     --bg-button: #21262d;
     --bg-button-hover: #30363d;
     --bg-input: #0d1117;
+    --bg-inset: #0d1117;
+    --bg-muted: #3d3d3d;
+    --bg-nav-active: #1f2937;
+    --border: #30363d;
     --fg-primary: #e6edf3;
     --fg-secondary: #c9d1d9;
-    --border: #30363d;
+    --fg-muted: #7d8590;
+    --fg-faint: #aaaaaa;
+    --accent: #58a6ff;
+    --accent-strong: #1f6feb;
+    --accent-strong-hover: #388bfd;
+    --accent-glow: #58a6ff80;
+    --danger: #da3633;
+    --danger-strong: #f85149;
+    --danger-surface: #5d1b1b;
+    --danger-border: #8b3030;
+    --danger-text: #ff8a80;
+    --ok: #3fb950;
+    --ok-surface: #1b3d2c;
+    --warn: #d29922;
+    --warn-surface: #3d2f00;
+    --warn-border: #5d4a00;
+    --warn-surface-2: #5d3b1b;
+    --advanced: #a371f7;
   }
-  /* Light theme — flips the chrome but leaves component-level cards in
-     the existing dark accent palette. A full light pass on every card
-     would be a separate effort; this gives users who run the OS in light
-     mode a much less jarring window frame. */
+
+  /* Light values — shared by explicit light and OS-light-when-unset. */
+  :global(:root[data-theme="light"]) {
+    color-scheme: light;
+    --bg-page: #f6f8fa;
+    --bg-surface: #ffffff;
+    --bg-surface-2: #f0f3f6;
+    --bg-button: #f1f3f5;
+    --bg-button-hover: #e7ebef;
+    --bg-input: #ffffff;
+    --bg-inset: #eef1f4;
+    --bg-muted: #e4e8ec;
+    --bg-nav-active: #ddeaff;
+    --border: #d0d7de;
+    --fg-primary: #1f2328;
+    --fg-secondary: #424a53;
+    --fg-muted: #656d76;
+    --fg-faint: #6e7781;
+    --accent: #0969da;
+    --accent-strong: #0969da;
+    --accent-strong-hover: #0860ca;
+    --accent-glow: #0969da55;
+    --danger: #cf222e;
+    --danger-strong: #cf222e;
+    --danger-surface: #ffebe9;
+    --danger-border: #ff9492;
+    --danger-text: #cf222e;
+    --ok: #1a7f37;
+    --ok-surface: #dafbe1;
+    --warn: #9a6700;
+    --warn-surface: #fff8c5;
+    --warn-border: #d4a72c;
+    --warn-surface-2: #fff1e5;
+    --advanced: #8250df;
+  }
   @media (prefers-color-scheme: light) {
-    :global(:root) {
+    :global(:root:not([data-theme])) {
       color-scheme: light;
       --bg-page: #f6f8fa;
-      --bg-chrome: #ffffff;
+      --bg-surface: #ffffff;
+      --bg-surface-2: #f0f3f6;
       --bg-button: #f1f3f5;
-      --bg-button-hover: #e1e4e8;
+      --bg-button-hover: #e7ebef;
       --bg-input: #ffffff;
-      --fg-primary: #24292f;
-      --fg-secondary: #57606a;
+      --bg-inset: #eef1f4;
+      --bg-muted: #e4e8ec;
+      --bg-nav-active: #ddeaff;
       --border: #d0d7de;
+      --fg-primary: #1f2328;
+      --fg-secondary: #424a53;
+      --fg-muted: #656d76;
+      --fg-faint: #6e7781;
+      --accent: #0969da;
+      --accent-strong: #0969da;
+      --accent-strong-hover: #0860ca;
+      --accent-glow: #0969da55;
+      --danger: #cf222e;
+      --danger-strong: #cf222e;
+      --danger-surface: #ffebe9;
+      --danger-border: #ff9492;
+      --danger-text: #cf222e;
+      --ok: #1a7f37;
+      --ok-surface: #dafbe1;
+      --warn: #9a6700;
+      --warn-surface: #fff8c5;
+      --warn-border: #d4a72c;
+      --warn-surface-2: #fff1e5;
+      --advanced: #8250df;
     }
   }
+
   :global(html, body) {
     margin: 0;
     padding: 0;
@@ -68,7 +181,7 @@
     box-sizing: border-box;
   }
   :global(a) {
-    color: #58a6ff;
+    color: var(--accent);
     text-decoration: none;
   }
   :global(a:hover) {
@@ -88,18 +201,20 @@
     background: var(--bg-button-hover);
   }
   :global(button.primary) {
-    background: #1f6feb;
-    border-color: #1f6feb;
+    background: var(--accent-strong);
+    border-color: var(--accent-strong);
+    color: #fff;
   }
   :global(button.primary:hover) {
-    background: #388bfd;
+    background: var(--accent-strong-hover);
   }
   :global(button.danger) {
-    background: #da3633;
-    border-color: #da3633;
+    background: var(--danger);
+    border-color: var(--danger);
+    color: #fff;
   }
   :global(button.danger:hover) {
-    background: #f85149;
+    background: var(--danger-strong);
   }
   :global(input, select) {
     background: var(--bg-input);
@@ -114,12 +229,12 @@
     color: var(--fg-secondary);
     opacity: 0.8;
   }
-  :global(.risk-safe) { color: #3fb950; }
-  :global(.risk-medium) { color: #d29922; }
-  :global(.risk-high) { color: #f85149; }
-  :global(.risk-advanced) { color: #a371f7; }
-  :global(.risk-unknown) { color: #d29922; font-weight: 500; }
-  :global(.risk-blocked) { color: #7d8590; font-weight: 500; }
+  :global(.risk-safe) { color: var(--ok); }
+  :global(.risk-medium) { color: var(--warn); }
+  :global(.risk-high) { color: var(--danger-strong); }
+  :global(.risk-advanced) { color: var(--advanced); }
+  :global(.risk-unknown) { color: var(--warn); font-weight: 500; }
+  :global(.risk-blocked) { color: var(--fg-muted); font-weight: 500; }
 
   .app {
     display: grid;
@@ -132,7 +247,7 @@
     justify-content: space-between;
     padding: 0.8rem 1.5rem;
     border-bottom: 1px solid var(--border);
-    background: var(--bg-chrome);
+    background: var(--bg-surface);
   }
   .brand {
     display: flex;
@@ -144,30 +259,59 @@
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background: #58a6ff;
-    box-shadow: 0 0 8px #58a6ff80;
+    background: var(--accent);
+    box-shadow: 0 0 8px var(--accent-glow);
   }
   .title {
     font-size: 1.05rem;
   }
   .version {
-    color: #7d8590;
+    color: var(--fg-muted);
     font-weight: 400;
     font-size: 0.85rem;
+  }
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 1.4rem;
   }
   nav {
     display: flex;
     gap: 1.2rem;
   }
   nav a {
-    color: #c9d1d9;
+    color: var(--fg-secondary);
     font-size: 0.92rem;
     padding: 0.3rem 0.5rem;
     border-radius: 4px;
   }
   nav a.active {
-    color: #58a6ff;
-    background: #1f2937;
+    color: var(--accent);
+    background: var(--bg-nav-active);
+  }
+  .theme-toggle {
+    display: flex;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .theme-toggle button {
+    border: none;
+    border-radius: 0;
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
+    background: transparent;
+    color: var(--fg-secondary);
+  }
+  .theme-toggle button:not(:last-child) {
+    border-right: 1px solid var(--border);
+  }
+  .theme-toggle button.active {
+    background: var(--accent-strong);
+    color: #fff;
+  }
+  .theme-toggle button:hover:not(.active) {
+    background: var(--bg-button-hover);
   }
   main {
     padding: 1.5rem;

--- a/v2/src/routes/+layout.svelte
+++ b/v2/src/routes/+layout.svelte
@@ -88,6 +88,7 @@
     --danger-surface: #5d1b1b;
     --danger-border: #8b3030;
     --danger-text: #ff8a80;
+    --danger-surface-text: #ffffff;
     --ok: #3fb950;
     --ok-surface: #1b3d2c;
     --warn: #d29922;
@@ -123,6 +124,7 @@
     --danger-surface: #ffebe9;
     --danger-border: #ff9492;
     --danger-text: #cf222e;
+    --danger-surface-text: #cf222e;
     --ok: #1a7f37;
     --ok-surface: #dafbe1;
     --warn: #9a6700;
@@ -157,6 +159,7 @@
       --danger-surface: #ffebe9;
       --danger-border: #ff9492;
       --danger-text: #cf222e;
+      --danger-surface-text: #cf222e;
       --ok: #1a7f37;
       --ok-surface: #dafbe1;
       --warn: #9a6700;

--- a/v2/src/routes/+page.svelte
+++ b/v2/src/routes/+page.svelte
@@ -417,9 +417,9 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.9rem 1rem;
-    border: 1px solid #30363d;
+    border: 1px solid var(--border);
     border-radius: 8px;
-    background: #161b22;
+    background: var(--bg-surface);
     margin-bottom: 0.6rem;
     transition: background 0.1s;
     text-decoration: none;
@@ -430,7 +430,7 @@
   }
   a.device-row:hover {
     text-decoration: none;
-    background: #1c2128;
+    background: var(--bg-surface-2);
   }
   .device-row.clickable {
     cursor: pointer;
@@ -442,7 +442,7 @@
     font-weight: 500;
   }
   .conn-tag {
-    color: #7d8590;
+    color: var(--fg-muted);
     font-size: 0.78rem;
     font-family: ui-monospace, monospace;
   }
@@ -452,19 +452,19 @@
     border-radius: 4px;
   }
   .status-tag.unauthorized {
-    background: #5d1b1b;
-    color: #ff8a80;
+    background: var(--danger-surface);
+    color: var(--danger-text);
   }
   .status-tag.offline {
-    background: #3d3d3d;
-    color: #aaa;
+    background: var(--bg-muted);
+    color: var(--fg-faint);
   }
   .device-meta {
     font-size: 0.82rem;
     margin-top: 0.2rem;
   }
   .chevron {
-    color: #7d8590;
+    color: var(--fg-muted);
     font-size: 1.4rem;
   }
   .empty {
@@ -474,11 +474,11 @@
   .empty h2 {
     margin: 0 0 0.6rem;
     font-size: 1.1rem;
-    color: #c9d1d9;
+    color: var(--fg-secondary);
   }
   .pair-form {
-    background: #161b22;
-    border: 1px solid #30363d;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1rem 1.2rem;
     margin-bottom: 1rem;
@@ -501,8 +501,8 @@
     flex: 0 0 8rem;
   }
   .report-all {
-    background: #161b22;
-    border: 1px solid #30363d;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1rem 1.2rem;
     margin-bottom: 1rem;
@@ -514,7 +514,7 @@
   .report-row {
     margin: 0.7rem 0;
     padding-bottom: 0.7rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--bg-button);
   }
   .report-row:last-child {
     border-bottom: none;
@@ -530,13 +530,13 @@
   .unauthorized-help {
     margin-top: 0.6rem;
     padding: 0.6rem 0.8rem;
-    background: #0d1117;
-    border: 1px solid #5d1b1b;
+    background: var(--bg-inset);
+    border: 1px solid var(--danger-surface);
     border-radius: 4px;
     font-size: 0.85rem;
   }
   .unauthorized-help strong {
-    color: #ff8a80;
+    color: var(--danger-text);
   }
   .unauthorized-help ol {
     margin: 0.4rem 0;
@@ -549,8 +549,8 @@
     align-items: flex-start;
   }
   .install-pane {
-    background: #161b22;
-    border: 1px solid #30363d;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1.5rem;
   }
@@ -571,16 +571,16 @@
     font-size: 0.82rem;
   }
   .error {
-    background: #5d1b1b;
-    color: #ff8a80;
+    background: var(--danger-surface);
+    color: var(--danger-text);
     padding: 0.7rem 1rem;
     border-radius: 6px;
     font-family: ui-monospace, monospace;
     font-size: 0.85rem;
   }
   code {
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     padding: 0.1rem 0.4rem;
     border-radius: 4px;
     font-family: ui-monospace, monospace;

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -1601,7 +1601,7 @@
                   {:else if progress === "skipped"}
                     <span class="muted small">skipped</span>
                   {:else if progress === "failed"}
-                    <span class="tag" style="background:#5d1b1b; color:#ff8a80" title={optimizeFailureMessages[item.entry.package] ?? ""}>FAILED</span>
+                    <span class="tag" style="background:var(--danger-surface); color:var(--danger-text)" title={optimizeFailureMessages[item.entry.package] ?? ""}>FAILED</span>
                   {/if}
                 </td>
               </tr>
@@ -1949,7 +1949,7 @@
     font-size: 1.5rem;
   }
   .device-meta {
-    color: #7d8590;
+    color: var(--fg-muted);
     font-size: 0.9rem;
     margin-top: 0.3rem;
     display: flex;
@@ -1964,7 +1964,7 @@
     display: flex;
     gap: 0.4rem;
     margin-bottom: 1rem;
-    border-bottom: 1px solid #30363d;
+    border-bottom: 1px solid var(--border);
     padding-bottom: 0;
   }
   .tabs button {
@@ -1975,12 +1975,12 @@
     padding: 0.5rem 0.8rem;
   }
   .tabs button.active {
-    color: #58a6ff;
-    border-bottom-color: #58a6ff;
+    color: var(--accent);
+    border-bottom-color: var(--accent);
   }
   .card {
-    background: #161b22;
-    border: 1px solid #30363d;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 1.2rem;
   }
@@ -1991,7 +1991,7 @@
   .card h3 {
     margin: 1rem 0 0.4rem;
     font-size: 1rem;
-    color: #c9d1d9;
+    color: var(--fg-secondary);
   }
   .card-header {
     display: flex;
@@ -2007,7 +2007,7 @@
     font-size: 0.9rem;
   }
   .kv dt {
-    color: #7d8590;
+    color: var(--fg-muted);
   }
   .kv dd {
     margin: 0;
@@ -2021,7 +2021,7 @@
   th, td {
     text-align: left;
     padding: 0.5rem 0.6rem;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--bg-button);
     vertical-align: middle;
   }
   th.center, td.center {
@@ -2051,7 +2051,7 @@
     margin-right: 0.5rem;
   }
   th {
-    color: #7d8590;
+    color: var(--fg-muted);
     font-weight: 500;
     font-size: 0.8rem;
     text-transform: uppercase;
@@ -2062,8 +2062,8 @@
     text-align: right;
     width: 100px;
   }
-  td.num.warn { color: #f85149; }
-  td.num.caution { color: #d29922; }
+  td.num.warn { color: var(--danger-strong); }
+  td.num.caution { color: var(--warn); }
   td.pkg, td.mono {
     font-family: ui-monospace, monospace;
     font-size: 0.85rem;
@@ -2089,7 +2089,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 0.7rem 0;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--bg-button);
   }
   .launcher-name {
     font-weight: 500;
@@ -2104,26 +2104,26 @@
     border-radius: 4px;
     letter-spacing: 0.04em;
   }
-  .tag.installed { background: #1b3d2c; color: #3fb950; }
-  .tag.missing { background: #3d3d3d; color: #aaa; }
-  .tag.disabled { background: #5d3b1b; color: #d29922; }
+  .tag.installed { background: var(--ok-surface); color: var(--ok); }
+  .tag.missing { background: var(--bg-muted); color: var(--fg-faint); }
+  .tag.disabled { background: var(--warn-surface-2); color: var(--warn); }
   .warning {
-    background: #3d2f00;
-    border: 1px solid #5d4a00;
-    color: #d29922;
+    background: var(--warn-surface);
+    border: 1px solid var(--warn-border);
+    color: var(--warn);
     padding: 0.7rem 1rem;
     border-radius: 6px;
     margin: 0.8rem 0;
     font-size: 0.9rem;
   }
   .warning code {
-    background: #0d1117;
+    background: var(--bg-inset);
     padding: 0.1rem 0.3rem;
     border-radius: 3px;
   }
   .error {
-    background: #5d1b1b;
-    color: #ff8a80;
+    background: var(--danger-surface);
+    color: var(--danger-text);
     padding: 0.7rem 1rem;
     border-radius: 6px;
     font-family: ui-monospace, monospace;
@@ -2132,8 +2132,8 @@
   .preview-box {
     margin-top: 1rem;
     padding: 1rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 6px;
   }
   .preview-box ul {
@@ -2153,7 +2153,7 @@
     gap: 0.4rem;
     align-items: center;
     font-size: 0.85rem;
-    color: #c9d1d9;
+    color: var(--fg-secondary);
     cursor: pointer;
   }
   .row-actions {
@@ -2167,40 +2167,40 @@
     font-size: 0.78rem;
   }
   .small-action.danger {
-    background: #21262d;
-    border-color: #5d1b1b;
-    color: #f85149;
+    background: var(--bg-button);
+    border-color: var(--danger-surface);
+    color: var(--danger-strong);
   }
   .small-action.danger:hover {
-    background: #5d1b1b;
+    background: var(--danger-surface);
     color: #fff;
-    border-color: #f85149;
+    border-color: var(--danger-strong);
   }
   .small-action.recommended {
-    background: #1f6feb;
+    background: var(--accent-strong);
     color: #fff;
-    border-color: #58a6ff;
+    border-color: var(--accent);
     font-weight: 500;
   }
   .small-action.recommended:hover:not(:disabled) {
-    background: #388bfd;
+    background: var(--accent-strong-hover);
   }
   .small-action.recommended.danger {
-    background: #5d1b1b;
-    border-color: #f85149;
+    background: var(--danger-surface);
+    border-color: var(--danger-strong);
     color: #fff;
   }
   .small-action.recommended.danger:hover:not(:disabled) {
-    background: #8b3030;
+    background: var(--danger-border);
   }
   .small-action.subtle {
     background: transparent;
-    border-color: #30363d;
-    color: #7d8590;
+    border-color: var(--border);
+    color: var(--fg-muted);
   }
   .small-action.subtle:hover:not(:disabled) {
-    background: #21262d;
-    color: #c9d1d9;
+    background: var(--bg-button);
+    color: var(--fg-secondary);
   }
   .state-badge {
     display: inline-block;
@@ -2212,22 +2212,22 @@
     font-family: ui-monospace, monospace;
   }
   .state-badge.state-enabled {
-    background: #1b3d2c;
-    color: #3fb950;
+    background: var(--ok-surface);
+    color: var(--ok);
   }
   .state-badge.state-disabled {
-    background: #5d3b1b;
-    color: #d29922;
+    background: var(--warn-surface-2);
+    color: var(--warn);
   }
   .state-badge.state-missing {
-    background: #3d3d3d;
-    color: #aaa;
+    background: var(--bg-muted);
+    color: var(--fg-faint);
   }
   .action-message {
     margin-top: 0.4rem;
     padding: 0.4rem 0.6rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     word-break: break-word;
   }
@@ -2250,8 +2250,8 @@
     top: 100%;
     right: 0;
     margin-top: 0.3rem;
-    background: #161b22;
-    border: 1px solid #30363d;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 6px;
     padding: 0.3rem;
     display: flex;
@@ -2266,27 +2266,27 @@
     border: none;
   }
   .reboot-menu button:hover {
-    background: #21262d;
+    background: var(--bg-button);
   }
   .recovery-section {
     margin-top: 1.5rem;
     padding-top: 1.2rem;
-    border-top: 1px solid #30363d;
+    border-top: 1px solid var(--border);
   }
   .danger-button {
-    background: #5d1b1b;
-    border-color: #8b3030;
+    background: var(--danger-surface);
+    border-color: var(--danger-border);
     color: #fff;
     margin-top: 0.6rem;
   }
   .danger-button:hover:not(:disabled) {
-    background: #8b3030;
+    background: var(--danger-border);
   }
   .recovery-result {
     margin-top: 0.8rem;
     padding: 0.6rem 0.8rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
   }
   .recovery-result ul {
@@ -2305,12 +2305,12 @@
     align-items: center;
     gap: 1rem;
     padding: 0.5rem 0;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--bg-button);
   }
   .small-action.active {
-    background: #1f6feb;
+    background: var(--accent-strong);
     color: #fff;
-    border-color: #58a6ff;
+    border-color: var(--accent);
   }
   .apply-row {
     display: flex;
@@ -2322,8 +2322,8 @@
   .apply-result {
     margin-top: 0.6rem;
     padding: 0.6rem 0.8rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
   }
   .apply-result ul {
@@ -2331,11 +2331,11 @@
     padding-left: 1.2rem;
   }
   .warn-text {
-    color: #d29922;
+    color: var(--warn);
   }
   .current-scaling {
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     padding: 0.5rem 0.7rem;
     margin: 0.4rem 0 0.6rem;
@@ -2354,13 +2354,13 @@
     text-align: left;
     padding: 0.6rem 0.8rem;
     gap: 0.2rem;
-    background: #21262d;
-    border: 1px solid #30363d;
+    background: var(--bg-button);
+    border: 1px solid var(--border);
     border-radius: 6px;
     cursor: pointer;
   }
   .scale-option:hover:not(:disabled) {
-    background: #30363d;
+    background: var(--border);
   }
   .scale-option .scale-title {
     font-weight: 500;
@@ -2369,7 +2369,7 @@
   .stock-wizard {
     margin-top: 1.5rem;
     padding-top: 1.2rem;
-    border-top: 1px solid #30363d;
+    border-top: 1px solid var(--border);
   }
   .handler-list {
     list-style: none;
@@ -2378,7 +2378,7 @@
   }
   .handler-list li {
     padding: 0.3rem 0;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--bg-button);
   }
   .handler-list .checkbox-row {
     display: flex;
@@ -2389,8 +2389,8 @@
   .plan-summary {
     margin: 0.4rem 0;
     padding: 0.5rem 0.8rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     font-size: 0.9rem;
   }
@@ -2402,12 +2402,12 @@
     align-items: center;
     gap: 0.4rem;
     font-size: 0.85rem;
-    color: #c9d1d9;
+    color: var(--fg-secondary);
     cursor: pointer;
   }
-  .action-disable { color: #58a6ff; font-weight: 500; }
-  .action-uninstall { color: #f85149; font-weight: 500; }
-  .action-enable { color: #3fb950; font-weight: 500; }
+  .action-disable { color: var(--accent); font-weight: 500; }
+  .action-uninstall { color: var(--danger-strong); font-weight: 500; }
+  .action-enable { color: var(--ok); font-weight: 500; }
   .legend {
     display: flex;
     align-items: center;
@@ -2415,16 +2415,16 @@
     gap: 0.4rem;
     margin: 0 0 0.8rem;
     padding: 0.5rem 0.8rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     line-height: 1.4;
   }
   .apk-folder {
     margin: 0.4rem 0;
     padding: 0.4rem 0.6rem;
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     word-break: break-all;
   }
@@ -2439,7 +2439,7 @@
     align-items: center;
     gap: 0.8rem;
     padding: 0.5rem 0;
-    border-bottom: 1px solid #21262d;
+    border-bottom: 1px solid var(--bg-button);
   }
   .apk-list li:last-child {
     border-bottom: none;
@@ -2450,8 +2450,8 @@
     word-break: break-all;
   }
   .install-output {
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     padding: 0.7rem 1rem;
     margin: 0.8rem 0;
@@ -2461,8 +2461,8 @@
     word-break: break-word;
   }
   code {
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     padding: 0.1rem 0.4rem;
     border-radius: 4px;
     font-family: ui-monospace, monospace;

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -2173,7 +2173,7 @@
   }
   .small-action.danger:hover {
     background: var(--danger-surface);
-    color: #fff;
+    color: var(--danger-surface-text);
     border-color: var(--danger-strong);
   }
   .small-action.recommended {
@@ -2188,7 +2188,7 @@
   .small-action.recommended.danger {
     background: var(--danger-surface);
     border-color: var(--danger-strong);
-    color: #fff;
+    color: var(--danger-surface-text);
   }
   .small-action.recommended.danger:hover:not(:disabled) {
     background: var(--danger-border);
@@ -2276,7 +2276,7 @@
   .danger-button {
     background: var(--danger-surface);
     border-color: var(--danger-border);
-    color: #fff;
+    color: var(--danger-surface-text);
     margin-top: 0.6rem;
   }
   .danger-button:hover:not(:disabled) {

--- a/v2/src/routes/snapshots/+page.svelte
+++ b/v2/src/routes/snapshots/+page.svelte
@@ -276,7 +276,7 @@
   }
   .small-action.danger:hover {
     background: var(--danger-surface);
-    color: #fff;
+    color: var(--danger-surface-text);
   }
   code {
     background: var(--bg-inset);

--- a/v2/src/routes/snapshots/+page.svelte
+++ b/v2/src/routes/snapshots/+page.svelte
@@ -205,8 +205,8 @@
     justify-content: space-between;
     gap: 1rem;
     padding: 0.7rem 1rem;
-    background: #161b22;
-    border: 1px solid #30363d;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 6px;
     margin-bottom: 0.5rem;
   }
@@ -236,14 +236,14 @@
     font-size: 1.1rem;
   }
   .error {
-    background: #5d1b1b;
-    color: #ff8a80;
+    background: var(--danger-surface);
+    color: var(--danger-text);
     padding: 0.7rem 1rem;
     border-radius: 6px;
   }
   .action-msg {
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     border-radius: 4px;
     padding: 0.6rem 0.8rem;
     margin: 0.5rem 0;
@@ -258,7 +258,7 @@
     border-radius: 4px;
     letter-spacing: 0.04em;
   }
-  .tag.installed { background: #1b3d2c; color: #3fb950; }
+  .tag.installed { background: var(--ok-surface); color: var(--ok); }
   .small {
     font-size: 0.82rem;
   }
@@ -270,17 +270,17 @@
     font-size: 0.78rem;
   }
   .small-action.danger {
-    background: #21262d;
-    border-color: #5d1b1b;
-    color: #f85149;
+    background: var(--bg-button);
+    border-color: var(--danger-surface);
+    color: var(--danger-strong);
   }
   .small-action.danger:hover {
-    background: #5d1b1b;
+    background: var(--danger-surface);
     color: #fff;
   }
   code {
-    background: #0d1117;
-    border: 1px solid #30363d;
+    background: var(--bg-inset);
+    border: 1px solid var(--border);
     padding: 0.1rem 0.4rem;
     border-radius: 4px;
     font-family: ui-monospace, monospace;


### PR DESCRIPTION
Light appearance left the cards and text in dark-mode colors over a light page, making text nearly unreadable on Linux/macOS (#26).

The UI is now fully theme-aware — every hardcoded color became a semantic CSS variable with a dark value (unchanged) and a contrast-tuned light value. A header **Light / Dark / Auto** toggle overrides the system appearance and persists; Auto follows the OS. Verified both themes and the override render correctly via the demo screenshot harness.

Closes #26