### PR TITLE
Review-pass bug fixes (stderr-aware success, snapshot settings, input validation)

### DIFF
--- a/v2/CHANGELOG.md
+++ b/v2/CHANGELOG.md
@@ -28,6 +28,26 @@ When you add a new section, put it at the top; older releases go below.
   Uninstall to a safer Disable, or skip individual rows, without giving up the
   recommendation. The do-not-disable safety list still gates every action.
 
+### Fixed
+
+- **Accurate success reporting for device actions.** Apply-snapshot,
+  disable/restore-stock-launchers, and Emergency Recovery judged success by
+  scanning only stdout — but `adb shell` exits 0 even when the on-device
+  command fails, and `pm` / `settings` write failures to stderr on many builds.
+  They now inspect both streams, so a package or setting that didn't actually
+  change is reported as failed instead of silently "done."
+- **Apply-snapshot no longer claims settings were written when they weren't.**
+  Settings are now applied one at a time and each is checked, so the summary
+  reflects what actually took (previously every key was reported written as
+  long as the shell ran).
+- **Hardened package-name and snapshot-value handling.** Package names from
+  manual-entry paths are validated before they reach the shell, and snapshot
+  setting values are rejected if they contain shell metacharacters (matching
+  the existing Tweaks guard).
+- Minor: the launcher-set error message no longer gets overwritten by benign
+  empty output, and per-device state is fully reset if the device view ever
+  switches devices without unmounting.
+
 ---
 
 ## v2-0.1.0-beta.6

--- a/v2/src-tauri/src/adb/driver.rs
+++ b/v2/src-tauri/src/adb/driver.rs
@@ -49,6 +49,22 @@ impl AdbOutput {
     pub fn success(&self) -> bool {
         self.exit_code == Some(0)
     }
+
+    /// stdout and stderr joined. `adb shell` exits 0 even when the on-device
+    /// command fails, and tools like `pm` / `settings` write their failure text
+    /// to *either* stream depending on the Android build — so any success
+    /// heuristic must look at both, not just stdout.
+    pub fn combined(&self) -> String {
+        format!("{}\n{}", self.stdout, self.stderr)
+    }
+
+    /// Heuristic for "did the on-device command report a failure?" Scans both
+    /// streams for the markers `pm` / `cmd` / `settings` emit on error. Use
+    /// this instead of checking `stdout` alone or trusting the exit code.
+    pub fn shell_reported_failure(&self) -> bool {
+        let combined = self.combined();
+        combined.contains("Failure") || combined.contains("Error") || combined.contains("Exception")
+    }
 }
 
 /// The driver abstraction. Lets tests inject a mock; production uses

--- a/v2/src-tauri/src/commands/apps.rs
+++ b/v2/src-tauri/src/commands/apps.rs
@@ -11,9 +11,24 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::adb::{parse_disabled_packages_output, parse_installed_packages_output};
-use crate::engine::{classify_safety, Safety};
+use crate::engine::{classify_safety, is_valid_package_name, Safety};
 
 use super::AppState;
+
+/// Reject malformed package names before they're interpolated into a shell
+/// command. Packages from `pm list` are well-formed, but the custom-launcher
+/// and any manual-entry path are user-controlled — this keeps a stray value
+/// from injecting shell syntax into `adb shell`. Returns an error result to
+/// surface verbatim if the name is invalid.
+fn reject_invalid_package(package: &str) -> Option<ActionResult> {
+    if is_valid_package_name(package) {
+        return None;
+    }
+    Some(ActionResult {
+        ok: false,
+        message: format!("Refusing to act on invalid package name: {package:?}"),
+    })
+}
 
 /// `safety_info` — pure lookup the frontend uses to decide between "show a
 /// loud confirm", "show a hard block badge", and "no extra ceremony".
@@ -88,6 +103,9 @@ pub async fn disable_package(
     serial: String,
     package: String,
 ) -> Result<ActionResult, String> {
+    if let Some(rejection) = reject_invalid_package(&package) {
+        return Ok(rejection);
+    }
     if let Safety::NeverDisable { reason } = classify_safety(&package) {
         return Ok(ActionResult {
             ok: false,
@@ -109,6 +127,9 @@ pub async fn enable_package(
     serial: String,
     package: String,
 ) -> Result<ActionResult, String> {
+    if let Some(rejection) = reject_invalid_package(&package) {
+        return Ok(rejection);
+    }
     run(&state, &serial, &format!("pm enable {package}")).await
 }
 
@@ -146,6 +167,9 @@ pub async fn uninstall_package(
     serial: String,
     package: String,
 ) -> Result<ActionResult, String> {
+    if let Some(rejection) = reject_invalid_package(&package) {
+        return Ok(rejection);
+    }
     if let Safety::NeverDisable { reason } = classify_safety(&package) {
         return Ok(ActionResult {
             ok: false,
@@ -169,6 +193,9 @@ pub async fn reinstall_existing(
     serial: String,
     package: String,
 ) -> Result<ActionResult, String> {
+    if let Some(rejection) = reject_invalid_package(&package) {
+        return Ok(rejection);
+    }
     run(
         &state,
         &serial,

--- a/v2/src-tauri/src/commands/launcher.rs
+++ b/v2/src-tauri/src/commands/launcher.rs
@@ -3,7 +3,7 @@
 use serde::Serialize;
 use tauri::State;
 
-use crate::engine::{launcher_catalog, LauncherEntry};
+use crate::engine::{is_valid_package_name, launcher_catalog, LauncherEntry};
 
 use super::AppState;
 
@@ -121,6 +121,17 @@ pub async fn set_default_launcher_impl(
     serial: &str,
     package: &str,
 ) -> Result<SetLauncherResult, String> {
+    // `package` can come from a custom-launcher entry the user typed, so it's
+    // interpolated into shell commands below — validate it first.
+    if !is_valid_package_name(package) {
+        return Ok(SetLauncherResult {
+            ok: false,
+            strategy: None,
+            current_launcher: None,
+            last_error: Some(format!("Invalid package name: {package:?}")),
+        });
+    }
+
     let adb = state.adb_snapshot().await;
 
     // 1. Enable the package — no-op for already-enabled.
@@ -176,11 +187,17 @@ pub async fn set_default_launcher_impl(
             format!("pm set-home-activity --user 0 {comp}"),
         ] {
             if let Ok(out) = adb.shell(serial, &cmd).await {
-                last_error = Some(if out.stderr.is_empty() {
-                    out.stdout.clone()
+                // Only record a diagnostic if the attempt actually printed
+                // something — set-home-activity is silent on success, so
+                // capturing its empty output would mask the real last error.
+                let msg = if out.stderr.trim().is_empty() {
+                    out.stdout.trim()
                 } else {
-                    out.stderr.clone()
-                });
+                    out.stderr.trim()
+                };
+                if !msg.is_empty() {
+                    last_error = Some(msg.to_string());
+                }
                 tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                 if active_launcher(&*adb, serial).await.as_deref() == Some(package) {
                     return Ok(SetLauncherResult {
@@ -401,7 +418,7 @@ pub async fn disable_stock_launchers(
         }
         let cmd = format!("pm disable-user --user 0 {pkg}");
         match adb.shell(&serial, &cmd).await {
-            Ok(out) if !out.stdout.contains("Failure") && !out.stdout.contains("Error") => {
+            Ok(out) if !out.shell_reported_failure() => {
                 processed.push(pkg);
             }
             _ => failed.push(pkg),
@@ -435,7 +452,7 @@ pub async fn restore_stock_launchers(
     let mut failed = Vec::new();
     for pkg in packages {
         match adb.shell(&serial, &format!("pm enable {pkg}")).await {
-            Ok(out) if !out.stdout.contains("Failure") && !out.stdout.contains("Error") => {
+            Ok(out) if !out.shell_reported_failure() => {
                 processed.push(pkg);
             }
             _ => failed.push(pkg),

--- a/v2/src-tauri/src/commands/recovery.rs
+++ b/v2/src-tauri/src/commands/recovery.rs
@@ -49,12 +49,12 @@ pub async fn panic_recovery(
 
     for pkg in &disabled {
         match adb.shell(&serial, &format!("pm enable {pkg}")).await {
-            Ok(out) if !out.stdout.contains("Failure") && !out.stdout.contains("Error") => {
+            Ok(out) if !out.shell_reported_failure() => {
                 restored.push(pkg.clone());
             }
             Ok(out) => failed.push(RecoveryFailure {
                 package: pkg.clone(),
-                error: out.stdout,
+                error: out.combined().trim().to_string(),
             }),
             Err(e) => failed.push(RecoveryFailure {
                 package: pkg.clone(),

--- a/v2/src-tauri/src/commands/snapshot.rs
+++ b/v2/src-tauri/src/commands/snapshot.rs
@@ -351,7 +351,7 @@ pub async fn apply_snapshot(
         }
         let cmd = format!("pm disable-user --user 0 {pkg}");
         match adb.shell(&serial, &cmd).await {
-            Ok(out) if !out.stdout.contains("Failure") && !out.stdout.contains("Error") => {
+            Ok(out) if !out.shell_reported_failure() => {
                 packages_disabled.push(pkg.clone());
             }
             _ => packages_failed.push(pkg.clone()),
@@ -385,28 +385,29 @@ pub async fn apply_snapshot(
     // 3. Write tracked settings — batch into a single shell call.
     let mut settings_written = Vec::new();
     let mut settings_failed = Vec::new();
-    if !plan.settings_to_write.is_empty() {
-        let mut parts = Vec::new();
-        let mut keys: Vec<&String> = Vec::new();
-        for (k, v) in &plan.settings_to_write {
-            // Key shape is `"ns.subkey"` per the snapshot schema.
-            if let Some((ns, key)) = k.split_once('.') {
-                parts.push(format!("settings put {ns} {key} {v}"));
-                keys.push(k);
-            }
+    // Apply one setting per shell call. Batching with `;` meant a single failing
+    // `settings put` (e.g. a SecurityException on a protected key) was invisible
+    // — `adb shell` still exits 0, so the old code reported every key written.
+    // Per-key lets us report exactly which succeeded, and check the output.
+    for (k, v) in &plan.settings_to_write {
+        // Key shape is `"ns.subkey"` per the snapshot schema.
+        let Some((ns, key)) = k.split_once('.') else {
+            settings_failed.push(format!("{k}: malformed key (expected ns.subkey)"));
+            continue;
+        };
+        // Snapshots are user-editable files on disk; reject values that could
+        // break out of the shell command, matching write_setting's guard.
+        if v.contains(';') || v.contains('|') || v.contains('&') {
+            settings_failed.push(format!("{k}: value contains shell metacharacters"));
+            continue;
         }
-        let cmd = parts.join("; ");
-        match adb.shell(&serial, &cmd).await {
-            Ok(_) => {
-                for k in keys {
-                    settings_written.push(k.clone());
-                }
-            }
-            Err(e) => {
-                for k in keys {
-                    settings_failed.push(format!("{k}: {e}"));
-                }
-            }
+        match adb
+            .shell(&serial, &format!("settings put {ns} {key} {v}"))
+            .await
+        {
+            Ok(out) if !out.shell_reported_failure() => settings_written.push(k.clone()),
+            Ok(out) => settings_failed.push(format!("{k}: {}", out.combined().trim())),
+            Err(e) => settings_failed.push(format!("{k}: {e}")),
         }
     }
 

--- a/v2/src-tauri/src/engine/mod.rs
+++ b/v2/src-tauri/src/engine/mod.rs
@@ -15,7 +15,7 @@ pub mod types;
 
 pub use app_lists::{AppList, AppListBundle};
 pub use detection::{detect_device_type, DeviceType};
-pub use launcher::{launcher_catalog, LauncherEntry};
+pub use launcher::{is_valid_package_name, launcher_catalog, LauncherEntry};
 pub use optimize::{compute_plan, OptimizeInputs, OptimizePlan};
 pub use safety::{classify as classify_safety, is_never_disable, Safety};
 pub use snapshot::{Snapshot, SnapshotApplyPlan, SnapshotError, SCHEMA_VERSION};

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -963,6 +963,44 @@
     }
   });
 
+  /// Wipe all per-device state. Used if the route's serial changes under a
+  /// live component (today the only way off this page is "← Back to devices",
+  /// so this is defensive — but it guarantees no device's data or in-flight
+  /// timer can leak onto another if a device→device link is ever added).
+  function resetDeviceState() {
+    if (liveRefreshTimer) {
+      clearInterval(liveRefreshTimer);
+      liveRefreshTimer = null;
+    }
+    liveRefresh = false;
+    activeTab = "overview";
+    device = null; deviceErr = null;
+    report = null; reportErr = null; reportLastRefreshed = null; safetyMap = {};
+    launchers = []; currentLauncher = null; channelDisabled = null;
+    launcherErr = null; launcherActionMessage = "";
+    homeHandlers = []; homeHandlersErr = null; homeHandlerSelections = {}; stockWizardResult = null;
+    apps = []; appsErr = null; appStates = {}; appActionMessage = "";
+    snapshots = []; snapshotsErr = null; preview = null; previewPath = null; previewErr = null; saveResult = "";
+    sideloadResult = ""; sideloadHint = null; discoveredApks = []; discoveredFolder = null;
+    headerActionMsg = ""; recoveryResult = null; recoveryErr = null;
+    applyResult = null; applyErr = null;
+    tweaks = null; tweaksErr = null; tweaksActionMessage = ""; currentDisplayScaling = null; displayScaleMessage = "";
+    optimizePlan = null; optimizePlanErr = null; optimizeOverrides = {};
+    optimizeProgress = {}; optimizeSummary = ""; optimizeFailureMessages = {}; optimizePerfApplied = false;
+  }
+
+  // Track the serial so a *change* (not the initial mount) resets and reloads.
+  // onMount handles the first load; this only fires if serial changes live.
+  let loadedSerial: string | null = null;
+  $effect(() => {
+    const s = serial;
+    if (loadedSerial !== null && loadedSerial !== s) {
+      resetDeviceState();
+      loadDevice();
+    }
+    loadedSerial = s;
+  });
+
   onMount(loadDevice);
 </script>
 


### PR DESCRIPTION
Fixes from a bug-hunt pass over v2. All verified against the actual code (false positives from the review were dropped).

- **stderr-blind success detection** — apply-snapshot, (dis/re)able-stock-launchers, and Emergency Recovery checked only stdout, but `adb shell` exits 0 even on on-device failure and `pm`/`settings` write errors to stderr on many builds. New `AdbOutput::shell_reported_failure()` scans both streams.
- **apply_snapshot over-reporting** — marked every setting "written" on `Ok(_)`. Now applies and checks each setting individually.
- **input validation** — wired up the previously-unused `is_valid_package_name()` on disable/enable/uninstall/reinstall + set_default_launcher; apply_snapshot rejects setting values with shell metacharacters.
- **minor** — launcher `last_error` no longer clobbered by benign empty output; defensive full per-device state reset on a live serial change (not reachable today, guards a future device→device link).

Safety gates (classify_safety on both disable and uninstall) unchanged. 73 tests pass; clippy/fmt/svelte-check/build clean.