### PR TITLE
v1 scan: surface devices waiting for on-TV authorization

### DIFF
--- a/Shield-Optimizer.ps1
+++ b/Shield-Optimizer.ps1
@@ -1290,11 +1290,21 @@ function Scan-Network {
 
     Write-Host "`r                              `r" -NoNewline  # Clear progress line
 
-    # Connect to found devices
+    # Connect to found devices. "failed to authenticate" means the TV is
+    # showing the "Allow USB debugging?" prompt — the device still registers
+    # as unauthorized, so tell the user what to do instead of staying silent.
+    $authPendingIps = @()
     foreach ($ip in $foundIps) {
         Write-Success "Found device at $ip"
-        & $Script:AdbPath connect $ip 2>$null | Out-Null
+        $connOutput = & $Script:AdbPath connect $ip 2>&1 | Out-String
+        if ($connOutput -match "failed to authenticate") {
+            $authPendingIps += $ip
+        }
         $foundCount++
+    }
+    if ($authPendingIps.Count -gt 0) {
+        Write-Warn "$($authPendingIps.Count) device(s) need authorization: $($authPendingIps -join ', ')"
+        Write-Host " Accept the 'Allow USB debugging?' prompt on each TV, then re-scan." -ForegroundColor $Script:Colors.Text
     }
 
     if ($foundCount -eq 0) {


### PR DESCRIPTION
Backport of the v2 scan fix (#35) to the PowerShell script: when `adb connect` returns `failed to authenticate` during a network scan, the device is registered as unauthorized but v1 stayed silent about it. Now the scan reports which IPs are waiting and tells the user to accept the "Allow USB debugging?" prompt and re-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)