### PR TITLE
Files: fix /sdcard symlink listing + Up button

### DIFF
--- a/v2/src-tauri/src/commands/files.rs
+++ b/v2/src-tauri/src/commands/files.rs
@@ -42,8 +42,12 @@ pub async fn list_dir(
 ) -> Result<Vec<FileEntry>, String> {
     let path = validate_sdcard_path(&path)?;
     let adb = state.adb_snapshot().await;
+    // Trailing slash matters: `/sdcard` is itself a symlink (to
+    // /storage/self/primary), and `ls -lA` on a bare symlink lists the link
+    // line instead of the directory contents. The slash forces dereference.
+    let slashed = format!("{}/", path.trim_end_matches('/'));
     let out = adb
-        .shell(&serial, &format!("ls -lA {}", quote_path(&path)))
+        .shell(&serial, &format!("ls -lA {}", quote_path(&slashed)))
         .await
         .map_err(|e| format!("ls: {e}"))?;
     let combined = out.combined();

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -2291,6 +2291,14 @@
       </details>
 
       <nav class="crumbs" aria-label="Path">
+        <button
+          class="small-action subtle"
+          onclick={() => goToFolder(filesPath)}
+          disabled={filesPath === "/sdcard" || filesLoading}
+          title="Up one level"
+        >
+          ↑ Up
+        </button>
         {#each crumbs as c, i (c.path)}
           {#if i > 0}<span class="muted">/</span>{/if}
           {#if i === crumbs.length - 1}


### PR DESCRIPTION
Beta feedback: "there is no way to navigate the files at all" — root cause reproduced on a real Shield: `/sdcard` is a symlink, and `ls -lA` on a bare symlink lists *the link itself* (one bogus 21-byte row) instead of the directory. Trailing slash forces dereference:

```
$ ls -lA /sdcard   → lrw-r--r-- … /sdcard -> /storage/self/primary
$ ls -lA /sdcard/  → the actual contents
```

Also adds an explicit **↑ Up** button. Part of the testing stack; gallery regen lands at the stack tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)