### PR TITLE
Launcher: disable-stock-takeover fallback for Set as default

### DIFF
--- a/v2/src-tauri/src/commands/launcher.rs
+++ b/v2/src-tauri/src/commands/launcher.rs
@@ -131,7 +131,10 @@ pub async fn current_launcher(
 pub struct SetLauncherResult {
     pub ok: bool,
     /// Identifier of the strategy that worked (or the last one tried on failure).
-    /// One of: "role_api", "set_home_activity", "home_intent_kick".
+    /// One of: "role_api", "set_home_activity", "home_intent_kick",
+    /// "disable_stock_takeover" (stock launcher disabled to hand HOME over —
+    /// the only method that works on builds whose role/set-home-activity
+    /// commands accept-but-ignore).
     pub strategy: Option<String>,
     /// Active launcher after the attempt — useful for the UI to render
     /// the post-action state.
@@ -291,6 +294,47 @@ pub async fn set_default_launcher_impl(
             current_launcher: now_active,
             last_error: None,
         });
+    }
+
+    // 5. The strategy that actually works on Android 11 TV builds where the
+    // role API silently no-ops and set-home-activity answers "Success"
+    // without effect (verified live on a Shield 2019 / Android 11): when the
+    // app holding HOME is a *stock* launcher, disable it — Android then
+    // resolves HOME to the remaining launcher. This is v1's proven
+    // Setup-Launcher mechanism, applied automatically and verified. Never
+    // auto-disables a custom launcher; the NEVER_DISABLE gate still applies;
+    // and if the takeover doesn't verify, the stock launcher is re-enabled.
+    if let Some(active) = now_active.clone() {
+        let active_is_stock = stock_launcher_catalog().iter().any(|e| e.package == active);
+        let blocked = matches!(
+            crate::engine::classify_safety(&active),
+            crate::engine::Safety::NeverDisable { .. }
+        );
+        if active != package && active_is_stock && !blocked {
+            let disabled_ok = matches!(
+                adb.shell(serial, &format!("pm disable-user --user 0 {active}")).await,
+                Ok(ref o) if !o.shell_reported_failure()
+            );
+            if disabled_ok {
+                let _ = adb
+                    .shell(
+                        serial,
+                        "am start -W -a android.intent.action.MAIN -c android.intent.category.HOME",
+                    )
+                    .await;
+                if verify_active(&*adb, serial, package).await {
+                    return Ok(SetLauncherResult {
+                        ok: true,
+                        strategy: Some("disable_stock_takeover".into()),
+                        current_launcher: Some(package.to_string()),
+                        last_error: None,
+                    });
+                }
+                // Takeover didn't verify — put the stock launcher back the
+                // way we found it rather than leaving a half-applied state.
+                let _ = adb.shell(serial, &format!("pm enable {active}")).await;
+            }
+        }
     }
 
     // The device acknowledged the change but the resolver never confirmed it.

--- a/v2/src-tauri/src/commands/launcher.rs
+++ b/v2/src-tauri/src/commands/launcher.rs
@@ -141,6 +141,11 @@ pub struct SetLauncherResult {
     pub current_launcher: Option<String>,
     /// Verbatim ADB error from the last failed attempt, if relevant.
     pub last_error: Option<String>,
+    /// True when the polite strategies failed but disabling the active
+    /// *stock* launcher would hand HOME to the target (the only working
+    /// method on accept-but-ignore builds). The UI asks the user and retries
+    /// with `allow_stock_disable` — it is never done silently.
+    pub stock_takeover_available: bool,
 }
 
 /// `set_default_launcher` — port of v1's multi-strategy promotion (PR #17/#18).
@@ -160,16 +165,26 @@ pub async fn set_default_launcher(
     state: State<'_, AppState>,
     serial: String,
     package: String,
+    allow_stock_disable: Option<bool>,
 ) -> Result<SetLauncherResult, String> {
-    set_default_launcher_impl(state.inner(), &serial, &package).await
+    set_default_launcher_impl(
+        state.inner(),
+        &serial,
+        &package,
+        allow_stock_disable.unwrap_or(false),
+    )
+    .await
 }
 
 /// Reusable implementation — callable from inside other commands without
 /// the `State<'_, T>` lifetime constraint getting in the way.
+/// `allow_stock_disable` opts into the disable-stock-takeover last resort;
+/// without it the caller gets `stock_takeover_available` back and decides.
 pub async fn set_default_launcher_impl(
     state: &AppState,
     serial: &str,
     package: &str,
+    allow_stock_disable: bool,
 ) -> Result<SetLauncherResult, String> {
     // `package` can come from a custom-launcher entry the user typed, so it's
     // interpolated into shell commands below — validate it first.
@@ -179,6 +194,7 @@ pub async fn set_default_launcher_impl(
             strategy: None,
             current_launcher: None,
             last_error: Some(format!("Invalid package name: {package:?}")),
+            stock_takeover_available: false,
         });
     }
 
@@ -208,6 +224,7 @@ pub async fn set_default_launcher_impl(
                     strategy: Some("role_api".into()),
                     current_launcher: Some(package.to_string()),
                     last_error: None,
+                    stock_takeover_available: false,
                 });
             }
             let msg = if out.stdout.trim().is_empty() {
@@ -262,6 +279,7 @@ pub async fn set_default_launcher_impl(
                             strategy: Some("set_home_activity".into()),
                             current_launcher: Some(package.to_string()),
                             last_error: None,
+                            stock_takeover_available: false,
                         });
                     }
                     // Accepted but the resolver didn't confirm: the preference
@@ -293,6 +311,7 @@ pub async fn set_default_launcher_impl(
             strategy: Some("home_intent_kick".into()),
             current_launcher: now_active,
             last_error: None,
+            stock_takeover_available: false,
         });
     }
 
@@ -301,9 +320,11 @@ pub async fn set_default_launcher_impl(
     // without effect (verified live on a Shield 2019 / Android 11): when the
     // app holding HOME is a *stock* launcher, disable it — Android then
     // resolves HOME to the remaining launcher. This is v1's proven
-    // Setup-Launcher mechanism, applied automatically and verified. Never
-    // auto-disables a custom launcher; the NEVER_DISABLE gate still applies;
-    // and if the takeover doesn't verify, the stock launcher is re-enabled.
+    // Setup-Launcher mechanism — but it is NEVER applied without the
+    // caller's explicit opt-in (`allow_stock_disable`); otherwise we report
+    // that the option exists and let the user decide. Never touches a custom
+    // launcher; the NEVER_DISABLE gate still applies; and if the takeover
+    // doesn't verify, the stock launcher is re-enabled.
     if let Some(active) = now_active.clone() {
         let active_is_stock = stock_launcher_catalog().iter().any(|e| e.package == active);
         let blocked = matches!(
@@ -311,6 +332,19 @@ pub async fn set_default_launcher_impl(
             crate::engine::Safety::NeverDisable { .. }
         );
         if active != package && active_is_stock && !blocked {
+            if !allow_stock_disable {
+                return Ok(SetLauncherResult {
+                    ok: false,
+                    strategy: None,
+                    current_launcher: Some(active.clone()),
+                    last_error: Some(format!(
+                        "This device ignores the standard launcher-switch commands. The only \
+                         way to hand HOME to {package} is to disable the stock launcher \
+                         ({active}) — it can be re-enabled from the list at any time."
+                    )),
+                    stock_takeover_available: true,
+                });
+            }
             let disabled_ok = matches!(
                 adb.shell(serial, &format!("pm disable-user --user 0 {active}")).await,
                 Ok(ref o) if !o.shell_reported_failure()
@@ -328,6 +362,7 @@ pub async fn set_default_launcher_impl(
                         strategy: Some("disable_stock_takeover".into()),
                         current_launcher: Some(package.to_string()),
                         last_error: None,
+                        stock_takeover_available: false,
                     });
                 }
                 // Takeover didn't verify — put the stock launcher back the
@@ -354,6 +389,7 @@ pub async fn set_default_launcher_impl(
         strategy: None,
         current_launcher: now_active,
         last_error,
+        stock_takeover_available: false,
     })
 }
 

--- a/v2/src-tauri/src/commands/snapshot.rs
+++ b/v2/src-tauri/src/commands/snapshot.rs
@@ -363,10 +363,14 @@ pub async fn apply_snapshot(
     let mut launcher_message = None;
     if let Some(launcher_pkg) = &plan.launcher_to_set {
         // Reuse the multi-strategy set-default helper from the launcher module.
+        // No stock takeover here: a snapshot that had stock disabled carries
+        // that in its disabled-packages list, so the polite strategies plus
+        // the package application get the same end state without surprises.
         let result = crate::commands::launcher::set_default_launcher_impl(
             state.inner(),
             &serial,
             launcher_pkg,
+            false,
         )
         .await;
         if let Ok(r) = result {

--- a/v2/src/lib/api.ts
+++ b/v2/src/lib/api.ts
@@ -75,8 +75,8 @@ export const api = {
     invoke<CurrentLauncher>("current_launcher", { serial }),
   channelProviderDisabled: (serial: string) =>
     invoke<boolean>("channel_provider_disabled", { serial }),
-  setDefaultLauncher: (serial: string, pkg: string) =>
-    invoke<SetLauncherResult>("set_default_launcher", { serial, package: pkg }),
+  setDefaultLauncher: (serial: string, pkg: string, allowStockDisable = false) =>
+    invoke<SetLauncherResult>("set_default_launcher", { serial, package: pkg, allowStockDisable }),
   disableLauncher: (serial: string, pkg: string) =>
     invoke<ActionResult>("disable_launcher", { serial, package: pkg }),
 

--- a/v2/src/lib/types.ts
+++ b/v2/src/lib/types.ts
@@ -138,6 +138,9 @@ export interface SetLauncherResult {
   strategy: string | null;
   current_launcher: string | null;
   last_error: string | null;
+  /// Polite strategies failed, but disabling the active stock launcher would
+  /// work — the UI confirms with the user and retries with allowStockDisable.
+  stock_takeover_available: boolean;
 }
 
 export interface InstallApkResult {

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -603,8 +603,10 @@
         await loadLauncher();
         launcherActionMessage = back.ok
           ? `Enabled ${pkg}. Android made it the active launcher, so ${prevDefault} was re-set as your default.`
-          : `Enabled ${pkg} — Android made it the active launcher, and re-setting ${prevDefault} failed` +
-            `${back.last_error ? `: ${back.last_error}` : ""}. Use "Set as default" on your preferred launcher.`;
+          : back.stock_takeover_available
+            ? `Enabled ${pkg} — it also took over HOME, and this build can't hand HOME back without disabling it again. Use "Set as default" on ${prevDefault} if you want it back.`
+            : `Enabled ${pkg} — Android made it the active launcher, and re-setting ${prevDefault} failed` +
+              `${back.last_error ? `: ${back.last_error}` : ""}. Use "Set as default" on your preferred launcher.`;
       } else {
         launcherActionMessage = `${pkg}: enabled`;
       }
@@ -637,11 +639,19 @@
     launcherActionBusy = pkg;
     launcherActionMessage = "";
     try {
-      const r = await api.setDefaultLauncher(serial, pkg);
+      let r = await api.setDefaultLauncher(serial, pkg);
+      if (!r.ok && r.stock_takeover_available) {
+        // The only working method on this build disables the stock launcher.
+        // Never do that silently — ask, then retry with the opt-in flag.
+        const proceed = confirm(
+          `${r.last_error ?? "This device ignores the standard launcher-switch commands."}\n\nDisable the stock launcher and switch to ${pkg}? You can re-enable it from this list at any time.`,
+        );
+        if (proceed) r = await api.setDefaultLauncher(serial, pkg, true);
+      }
       if (r.ok) {
         launcherActionMessage =
           r.strategy === "disable_stock_takeover"
-            ? `Set ${pkg} as default. This device ignores the standard launcher-switch commands, so the stock launcher was disabled to hand HOME over — re-enable it from the list any time.`
+            ? `Set ${pkg} as default — the stock launcher was disabled to hand HOME over (re-enable it from the list any time).`
             : `Set ${pkg} as default launcher (via ${r.strategy ?? "ok"}).`;
         await loadLauncher();
       } else {

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -639,7 +639,10 @@
     try {
       const r = await api.setDefaultLauncher(serial, pkg);
       if (r.ok) {
-        launcherActionMessage = `Set ${pkg} as default launcher (via ${r.strategy ?? "ok"}).`;
+        launcherActionMessage =
+          r.strategy === "disable_stock_takeover"
+            ? `Set ${pkg} as default. This device ignores the standard launcher-switch commands, so the stock launcher was disabled to hand HOME over — re-enable it from the list any time.`
+            : `Set ${pkg} as default launcher (via ${r.strategy ?? "ok"}).`;
         await loadLauncher();
       } else {
         // Backend messages are full sentences (including the "device accepted


### PR DESCRIPTION
Beta feedback: "tried to set Projectivy as default… didn't succeed… nothing happened." Diagnosed live on the real Shield:

- `cmd role add-role-holder` exits silently and does nothing (`get-role-holders` is `Unknown command`)
- `cmd package set-home-activity` answers **Success** — and a real HOME press still launches stock
- i.e. on Android 11 TV builds, **no shell command switches HOME while stock is enabled**, making "Set as default" + the hidden Disable on the active row a complete deadlock

New verified strategy 5, `disable_stock_takeover`: when the active launcher is a *stock* one, disable it → fire HOME → verify the target took over (re-enable stock if it didn't). Never auto-disables a custom launcher; NEVER_DISABLE gate honored. Verified end-to-end on the Shield — HOME resolved to Projectivy and it took the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)