### PR TITLE
Catalog: promote popular sideloaded TV apps to first-class entries

### DIFF
--- a/v2/data/app-lists/common.json
+++ b/v2/data/app-lists/common.json
@@ -537,5 +537,137 @@
     "default_optimize": false,
     "default_restore": true,
     "play_store": true
+  },
+  {
+    "package": "org.smarttube.stable",
+    "name": "SmartTube",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Ad-free YouTube client with SponsorBlock (sideloaded — not on the Play Store).",
+    "restore_description": "Re-enables SmartTube.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": false
+  },
+  {
+    "package": "io.gh.reisxd.tizentube.cobalt",
+    "name": "TizenTube Cobalt",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Ad-free YouTube client (Cobalt build for Android TV, sideloaded).",
+    "restore_description": "Re-enables TizenTube Cobalt.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": false
+  },
+  {
+    "package": "org.xbmc.kodi",
+    "name": "Kodi",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Open-source media center.",
+    "restore_description": "Re-enables Kodi.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "org.videolan.vlc",
+    "name": "VLC",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Plays virtually any audio or video file.",
+    "restore_description": "Re-enables VLC.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "com.limelight",
+    "name": "Moonlight Game Streaming",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Stream PC games to your TV (NVIDIA GameStream / Sunshine).",
+    "restore_description": "Re-enables Moonlight.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "com.limelight.noir",
+    "name": "Moonlight Noir",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Community fork of Moonlight with extra HDR / codec options (sideloaded).",
+    "restore_description": "Re-enables Moonlight Noir.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": false
+  },
+  {
+    "package": "com.valvesoftware.steamlink",
+    "name": "Steam Link",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Stream your Steam library from a PC on your network.",
+    "restore_description": "Re-enables Steam Link.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "com.codingbuffalo.aerialdream",
+    "name": "Aerial Dream",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Apple TV-style aerial video screensaver.",
+    "restore_description": "Re-enables Aerial Dream.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "com.cybercat.adbappcontrol.tv",
+    "name": "ADB TV: App Manager",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "On-device app manager — disable / uninstall apps via ADB, no PC.",
+    "restore_description": "Re-enables ADB TV.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "com.lonelycatgames.Xplore",
+    "name": "X-plore File Manager",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Dual-pane file manager for Android TV.",
+    "restore_description": "Re-enables X-plore.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "com.yablio.sendfilestotv",
+    "name": "Send Files to TV",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Wireless file transfer between a phone and the TV.",
+    "restore_description": "Re-enables Send Files to TV.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
+  },
+  {
+    "package": "flar2.homebutton",
+    "name": "Button Mapper",
+    "method": "disable",
+    "risk": "safe",
+    "optimize_description": "Remap remote / hardware buttons to custom actions.",
+    "restore_description": "Re-enables Button Mapper.",
+    "default_optimize": false,
+    "default_restore": false,
+    "play_store": true
   }
 ]

--- a/v2/src/lib/sideload-catalog.json
+++ b/v2/src/lib/sideload-catalog.json
@@ -1,9 +1,15 @@
 [
   {
     "name": "SmartTube",
-    "package": "com.teamsmart.videomanager.tv",
+    "package": "org.smarttube.stable",
     "description": "Ad-free YouTube client built for Android TV — SponsorBlock, adjustable speed, no Shorts. Not on the Play Store; download the stable APK from the official GitHub.",
     "url": "https://github.com/yuliskov/SmartTube"
+  },
+  {
+    "name": "TizenTube Cobalt",
+    "package": "io.gh.reisxd.tizentube.cobalt",
+    "description": "Ad-free YouTube with SponsorBlock and DeArrow — the Cobalt build runs on Android TV. Sideload from the official GitHub releases.",
+    "url": "https://github.com/reisxd/TizenTubeCobalt/releases"
   },
   {
     "name": "F-Droid",


### PR DESCRIPTION
Beta feedback: apps seen on both Shields showed as bare package IDs in "Everything else" and "should be more first-class citizens."

Added 12 **researched** catalog entries (Keep by default, safe, reversible) so they appear with friendly names, descriptions, and **audited** Play Store links: SmartTube, TizenTube Cobalt, Kodi, VLC, Moonlight (+ Noir fork), Steam Link, Aerial Dream, ADB TV: App Manager, X-plore, Send Files to TV, Button Mapper. Play-Store flags verified per package — SmartTube / TizenTube / Moonlight-Noir are sideload-only (no Play button, avoiding the 404s #32 fixed).

Also fixes the sideload catalog (#48): SmartTube's package was wrong (`com.teamsmart.videomanager.tv` → `org.smarttube.stable`), and adds **TizenTube Cobalt** as a popular sideload per your note.

Sources: [SmartTube GitHub](https://github.com/yuliskov/SmartTube), [TizenTube Cobalt](https://github.com/reisxd/TizenTubeCobalt), [Moonlight](https://play.google.com/store/apps/details?id=com.limelight), [ADB TV](https://play.google.com/store/apps/details?id=com.cybercat.adbappcontrol.tv), [Aerial Dream](https://play.google.com/store/apps/details?id=com.codingbuffalo.aerialdream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)