### PR TITLE
CI: bump actions/setup-node to v5 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/v2-release.yml
+++ b/.github/workflows/v2-release.yml
@@ -146,7 +146,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
@@ -305,7 +305,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm


### PR DESCRIPTION
GitHub force-migrates Node 20 actions on **2026-06-16** (10 days out). `actions/setup-node@v5` runs on Node 24; bumped in both v2 workflows. `checkout@v5` and `cache@v4` (latest major) already pull Node-24 builds. Independent of the feature stack — safe to merge anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)