### PR TITLE
Fix Wayland AppImage blank window; clarify Virtual Remote Keyboard

### DIFF
--- a/v2/data/app-lists/common.json
+++ b/v2/data/app-lists/common.json
@@ -288,7 +288,7 @@
     "name": "Virtual Remote Keyboard",
     "method": "disable",
     "risk": "medium",
-    "optimize_description": "Background phone-as-keyboard service. Disable if you don't use the Google TV mobile remote.",
+    "optimize_description": "Background keyboard/remote service. Powers the Google TV mobile remote and the Android TV Remote integration used by smart-home apps like Home Assistant. Disable only if you use none of those.",
     "restore_description": "Restores virtual remote keyboard.",
     "default_optimize": false,
     "default_restore": true,

--- a/v2/src-tauri/src/lib.rs
+++ b/v2/src-tauri/src/lib.rs
@@ -30,6 +30,15 @@ fn default_data_dir() -> PathBuf {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Some Wayland/Mesa setups crash WebKitGTK's DMABUF renderer on startup
+    // ("Could not create default EGL display: EGL_BAD_PARAMETER"), leaving a
+    // blank window. Disabling that renderer falls back to a path that works
+    // everywhere. Honor an existing value so power users can still force it on.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DISABLE_DMABUF_RENDERER").is_none() {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     // Best-effort tracing setup; fall back silently if EnvFilter parse fails.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(


### PR DESCRIPTION
Two small fixes from beta.11 feedback.

**#60 — AppImage blank window on Wayland.** WebKitGTK's DMABUF renderer crashes on some Wayland/Mesa setups (`Could not create default EGL display: EGL_BAD_PARAMETER`), leaving a blank window. We now set `WEBKIT_DISABLE_DMABUF_RENDERER=1` at Linux startup, honoring an existing value so power users can still force it on. Removes the need for the `LD_PRELOAD=libwayland-client` workaround.

**#58 — Virtual Remote Keyboard.** Widened the optimize description to call out the Android TV Remote integration used by smart-home apps like Home Assistant. It was already opt-in (`default_optimize: false`), so this is a clarity fix.

Fixes #60
Fixes #58