### PR TITLE
App catalog: verify play_store/defunct flags on flagged entries

### DIFF
--- a/v2/data/app-lists/common.json
+++ b/v2/data/app-lists/common.json
@@ -347,7 +347,7 @@
     "restore_description": "Restores Discovery+.",
     "default_optimize": false,
     "default_restore": false,
-    "play_store": false,
+    "play_store": true,
     "review": true
   },
   {
@@ -367,11 +367,12 @@
     "name": "YouTube Kids",
     "method": "uninstall",
     "risk": "safe",
-    "optimize_description": "Streaming App.",
-    "restore_description": "Restores YouTube Kids.",
+    "optimize_description": "Dedicated TV app discontinued July 2024 — kids profiles now in the main YouTube app.",
+    "restore_description": "Restores defunct app.",
     "default_optimize": false,
     "default_restore": false,
     "play_store": false,
+    "defunct": true,
     "review": true
   },
   {
@@ -460,11 +461,11 @@
   },
   {
     "package": "com.starz.starzplay.android",
-    "name": "STARZ",
+    "name": "LIONSGATE+",
     "method": "uninstall",
     "risk": "safe",
     "optimize_description": "Streaming App.",
-    "restore_description": "Restores STARZ.",
+    "restore_description": "Restores LIONSGATE+.",
     "default_optimize": false,
     "default_restore": false,
     "play_store": false,
@@ -475,11 +476,12 @@
     "name": "Showtime",
     "method": "uninstall",
     "risk": "safe",
-    "optimize_description": "Streaming App.",
-    "restore_description": "Restores Showtime.",
+    "optimize_description": "Service shut down April 2024 (merged into Paramount+).",
+    "restore_description": "Restores defunct app.",
     "default_optimize": false,
     "default_restore": false,
     "play_store": false,
+    "defunct": true,
     "review": true
   },
   {
@@ -511,11 +513,12 @@
     "name": "MGM+",
     "method": "uninstall",
     "risk": "safe",
-    "optimize_description": "Streaming App.",
-    "restore_description": "Restores MGM+.",
+    "optimize_description": "Old Epix Now Android TV package — replaced by MGM+ (com.epix.epix.now).",
+    "restore_description": "Restores defunct app.",
     "default_optimize": false,
     "default_restore": false,
     "play_store": false,
+    "defunct": true,
     "review": true
   },
   {

--- a/v2/src-tauri/src/commands/install.rs
+++ b/v2/src-tauri/src/commands/install.rs
@@ -63,6 +63,12 @@ pub struct RestartResult {
 /// USB-cable swap. Does not redownload — for that use `install_adb`.
 #[tauri::command]
 pub async fn restart_adb(state: State<'_, AppState>) -> Result<RestartResult, String> {
+    restart_adb_impl(state.inner()).await
+}
+
+/// Reusable implementation — callable from tests against an `AppState` without
+/// the `State<'_, T>` lifetime constraint.
+async fn restart_adb_impl(state: &AppState) -> Result<RestartResult, String> {
     let adb = state.adb_snapshot().await;
 
     // kill-server drops every TCP connection. USB devices re-enumerate on
@@ -157,5 +163,53 @@ pub async fn install_adb(state: State<'_, AppState>) -> Result<InstallResult, St
             path: None,
             message: e.to_string(),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::test_support::{state_with, MockAdb};
+
+    #[tokio::test]
+    async fn restart_adb_reports_failure_when_network_reconnect_fails() {
+        // Daemon restarts fine, but the previously-connected network device
+        // can't be reconnected — that's a user-visible failure, and the message
+        // must name the device and point at the recovery action.
+        let serial = "192.168.1.50:5555";
+        let mock = MockAdb::default()
+            .on_raw(
+                "devices",
+                &format!("List of devices attached\n{serial}\tdevice\n"),
+            )
+            .on_raw("start-server", "* daemon started successfully")
+            .on_raw_err("connect", "connection refused");
+        let state = state_with(mock);
+
+        let res = restart_adb_impl(&state).await.unwrap();
+
+        assert!(!res.ok);
+        assert!(
+            res.message.contains("Could not reconnect") && res.message.contains(serial),
+            "message should name the unreconnected device: {}",
+            res.message
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_adb_reports_failure_when_start_server_errors() {
+        // No network devices to reconnect, but start-server itself fails — the
+        // result must be a failure carrying the daemon's error text.
+        let mock = MockAdb::default().on_raw_err("start-server", "cannot bind to port 5037");
+        let state = state_with(mock);
+
+        let res = restart_adb_impl(&state).await.unwrap();
+
+        assert!(!res.ok);
+        assert!(
+            res.message.contains("cannot bind to port 5037"),
+            "message should surface the daemon error: {}",
+            res.message
+        );
     }
 }

--- a/v2/src-tauri/src/commands/launcher.rs
+++ b/v2/src-tauri/src/commands/launcher.rs
@@ -490,6 +490,142 @@ pub async fn channel_provider_disabled(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::test_support::{state_with, MockAdb};
+
+    #[tokio::test]
+    async fn set_launcher_first_strategy_wins_and_skips_the_rest() {
+        // Role API succeeds and the resolver confirms it — the fallback ladder
+        // (set-home-activity, query-activities, HOME-intent kick) must not run.
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Success")
+            .on_shell("resolve-activity", "com.example.launcher/.MainActivity");
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", false)
+            .await
+            .unwrap();
+
+        assert!(res.ok);
+        assert_eq!(res.strategy.as_deref(), Some("role_api"));
+        assert_eq!(
+            res.current_launcher.as_deref(),
+            Some("com.example.launcher")
+        );
+
+        let calls = log.lock().unwrap();
+        assert!(!calls.iter().any(|c| c.contains("set-home-activity")));
+        assert!(!calls.iter().any(|c| c.contains("query-activities")));
+        assert!(!calls.iter().any(|c| c.contains("am start")));
+    }
+
+    #[tokio::test]
+    async fn set_launcher_falls_back_to_set_home_activity_when_role_unsupported() {
+        // Build doesn't know the role command; the set-home-activity fallback
+        // takes over and verifies.
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Unknown command")
+            .on_shell("set-home-activity", "Success")
+            .on_shell("resolve-activity", "com.example.launcher/.MainActivity");
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", false)
+            .await
+            .unwrap();
+
+        assert!(res.ok);
+        assert_eq!(res.strategy.as_deref(), Some("set_home_activity"));
+
+        let calls = log.lock().unwrap();
+        assert!(calls.iter().any(|c| c.contains("add-role-holder")));
+        assert!(calls.iter().any(|c| c.contains("set-home-activity")));
+    }
+
+    #[tokio::test]
+    async fn set_launcher_reports_failure_with_reason_when_all_strategies_fail() {
+        // Role errors out, set-home-activity returns a real error, the resolver
+        // never names the target — the result should fail and surface why.
+        let mock = MockAdb::default()
+            .on_shell_err("add-role-holder", "secure connection refused")
+            .on_shell_failure("set-home-activity", "Error: Activity class does not exist");
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", false)
+            .await
+            .unwrap();
+
+        assert!(!res.ok);
+        assert_eq!(res.strategy, None);
+        let err = res.last_error.expect("a failure reason");
+        assert!(
+            err.contains("Activity class does not exist"),
+            "unhelpful failure message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_launcher_stock_takeover_reverts_when_it_does_not_verify() {
+        // Resolver always names the stock launcher, so the takeover never
+        // verifies — the stock launcher must be re-enabled (revert).
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Unknown command")
+            .on_shell_failure("set-home-activity", "Error: no such activity")
+            .on_shell("resolve-activity", "com.google.android.tvlauncher/.Home");
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", true)
+            .await
+            .unwrap();
+
+        assert!(!res.ok);
+        let calls = log.lock().unwrap();
+        assert!(calls
+            .iter()
+            .any(|c| c == "pm disable-user --user 0 com.google.android.tvlauncher"));
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "pm enable com.google.android.tvlauncher"),
+            "stock launcher should be re-enabled after a failed takeover"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_launcher_stock_takeover_does_not_revert_when_it_verifies() {
+        // Resolver reports the stock launcher until it is disabled, then the
+        // target — the takeover verifies, so no revert should be issued.
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Unknown command")
+            .on_shell_failure("set-home-activity", "Error: no such activity")
+            .on_shell_seq(
+                "resolve-activity",
+                &[
+                    "com.google.android.tvlauncher/.Home",
+                    "com.example.launcher/.MainActivity",
+                ],
+            );
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", true)
+            .await
+            .unwrap();
+
+        assert!(res.ok);
+        assert_eq!(res.strategy.as_deref(), Some("disable_stock_takeover"));
+        let calls = log.lock().unwrap();
+        assert!(calls
+            .iter()
+            .any(|c| c == "pm disable-user --user 0 com.google.android.tvlauncher"));
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c == "pm enable com.google.android.tvlauncher"),
+            "no revert expected after a verified takeover"
+        );
+    }
 
     #[test]
     fn parses_home_handler_packages_from_resolveinfo() {

--- a/v2/src-tauri/src/commands/mod.rs
+++ b/v2/src-tauri/src/commands/mod.rs
@@ -50,31 +50,98 @@ pub(crate) fn quote_shell_arg(s: &str) -> String {
 /// reusable `_impl` against it without a real device.
 #[cfg(test)]
 pub mod test_support {
-    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
 
-    use crate::adb::{AdbDriver, AdbOutput, AdbResult};
+    use crate::adb::{AdbDriver, AdbError, AdbOutput, AdbResult};
     use crate::engine::AppListBundle;
 
     use super::AppState;
 
+    /// One canned response. `Ok` returns it as stdout (exit 0); `Err` makes the
+    /// call return a typed `AdbError` so command error branches get exercised.
+    enum Reply {
+        Ok(String),
+        Err(String),
+    }
+
+    /// A substring rule plus its (possibly sequenced) responses. `cursor`
+    /// advances per matching call and sticks on the last reply, so a single
+    /// needle can hand back different outputs across calls — needed to model a
+    /// resolver whose answer changes after a `pm disable-user`.
+    struct Rule {
+        needle: String,
+        replies: Vec<Reply>,
+        cursor: AtomicUsize,
+    }
+
+    impl Rule {
+        fn single(needle: &str, reply: Reply) -> Self {
+            Self {
+                needle: needle.into(),
+                replies: vec![reply],
+                cursor: AtomicUsize::new(0),
+            }
+        }
+    }
+
     #[derive(Default)]
     pub struct MockAdb {
-        shell_rules: Vec<(String, String)>,
-        raw_rules: Vec<(String, String)>,
+        shell_rules: Vec<Rule>,
+        raw_rules: Vec<Rule>,
+        shell_log: Arc<Mutex<Vec<String>>>,
     }
 
     impl MockAdb {
         /// Return `stdout` for any `shell` whose command contains `needle`.
         pub fn on_shell(mut self, needle: &str, stdout: &str) -> Self {
-            self.shell_rules.push((needle.into(), stdout.into()));
+            self.shell_rules
+                .push(Rule::single(needle, Reply::Ok(stdout.into())));
+            self
+        }
+        /// Make matching `shell` calls fail with a typed `AdbError` carrying
+        /// `err_message` — the subprocess-failure branch (nonzero exit).
+        pub fn on_shell_err(mut self, needle: &str, err_message: &str) -> Self {
+            self.shell_rules
+                .push(Rule::single(needle, Reply::Err(err_message.into())));
+            self
+        }
+        /// Matching `shell` calls return Ok but with output that trips
+        /// `shell_reported_failure()` — how `pm`/`cmd` report errors without a
+        /// nonzero exit. Pass a `stdout` containing "Failure"/"Error". Distinct
+        /// name from `on_shell` keeps the intent legible at the call site.
+        pub fn on_shell_failure(self, needle: &str, stdout: &str) -> Self {
+            self.on_shell(needle, stdout)
+        }
+        /// Hand back `responses` in order for successive matching `shell` calls,
+        /// sticking on the last once exhausted.
+        pub fn on_shell_seq(mut self, needle: &str, responses: &[&str]) -> Self {
+            self.shell_rules.push(Rule {
+                needle: needle.into(),
+                replies: responses.iter().map(|s| Reply::Ok((*s).into())).collect(),
+                cursor: AtomicUsize::new(0),
+            });
             self
         }
         /// Return `stdout` for any `raw` whose joined args contain `needle`.
         pub fn on_raw(mut self, needle: &str, stdout: &str) -> Self {
-            self.raw_rules.push((needle.into(), stdout.into()));
+            self.raw_rules
+                .push(Rule::single(needle, Reply::Ok(stdout.into())));
             self
+        }
+        /// Make matching `raw` calls fail with a typed `AdbError`.
+        pub fn on_raw_err(mut self, needle: &str, err_message: &str) -> Self {
+            self.raw_rules
+                .push(Rule::single(needle, Reply::Err(err_message.into())));
+            self
+        }
+        /// Shared handle to the recorded `shell` command log. Grab it before
+        /// moving the mock into `state_with`, then assert on side-effect
+        /// commands (e.g. that a revert `pm enable` was — or wasn't — issued).
+        pub fn shell_log(&self) -> Arc<Mutex<Vec<String>>> {
+            Arc::clone(&self.shell_log)
         }
     }
 
@@ -86,24 +153,36 @@ pub mod test_support {
         })
     }
 
+    /// First-match-wins across rules in registration order, advancing the
+    /// matched rule's cursor. Unmatched calls succeed with empty stdout, so
+    /// existing tests that register no rules keep their default behavior.
+    fn reply_for(rules: &[Rule], haystack: &str) -> AdbResult<AdbOutput> {
+        for rule in rules {
+            if haystack.contains(rule.needle.as_str()) {
+                let idx = rule
+                    .cursor
+                    .fetch_add(1, Ordering::Relaxed)
+                    .min(rule.replies.len() - 1);
+                return match &rule.replies[idx] {
+                    Reply::Ok(out) => ok(out.clone()),
+                    Reply::Err(msg) => Err(AdbError::NonZeroExit {
+                        code: Some(1),
+                        stderr: msg.clone(),
+                    }),
+                };
+            }
+        }
+        ok(String::new())
+    }
+
     #[async_trait]
     impl AdbDriver for MockAdb {
         async fn raw(&self, args: &[&str]) -> AdbResult<AdbOutput> {
-            let joined = args.join(" ");
-            for (needle, out) in &self.raw_rules {
-                if joined.contains(needle.as_str()) {
-                    return ok(out.clone());
-                }
-            }
-            ok(String::new())
+            reply_for(&self.raw_rules, &args.join(" "))
         }
         async fn shell(&self, _serial: &str, command: &str) -> AdbResult<AdbOutput> {
-            for (needle, out) in &self.shell_rules {
-                if command.contains(needle.as_str()) {
-                    return ok(out.clone());
-                }
-            }
-            ok(String::new())
+            self.shell_log.lock().unwrap().push(command.to_string());
+            reply_for(&self.shell_rules, command)
         }
     }
 

--- a/v2/src-tauri/src/commands/snapshot.rs
+++ b/v2/src-tauri/src/commands/snapshot.rs
@@ -548,4 +548,21 @@ mod tests {
             failed[0]
         );
     }
+
+    #[tokio::test]
+    async fn disable_from_plan_records_pm_failure_without_aborting() {
+        // `pm disable-user` reports failure via stdout while `adb shell` still
+        // exits 0 — that package must land in packages_failed, the others must
+        // still succeed.
+        let mock = MockAdb::default()
+            .on_shell_failure("com.fails.pkg", "Failure [not installed for user 0]");
+        let pkgs = vec![
+            "com.ok.one".to_string(),
+            "com.fails.pkg".to_string(),
+            "com.ok.two".to_string(),
+        ];
+        let (disabled, failed) = disable_from_plan(&mock, "serial", &pkgs).await;
+        assert_eq!(disabled, ["com.ok.one", "com.ok.two"]);
+        assert_eq!(failed, ["com.fails.pkg"]);
+    }
 }


### PR DESCRIPTION
Audit follow-up: since beta.11, `play_store`/`defunct` drive the uninstall-safety gate (non-reinstallable → downgrade to disable), so wrong flags make the wizard needlessly conservative or unsafe. Web-verified all 8 flagged entries:

| Entry | Change | Why |
|---|---|---|
| Discovery+ | `play_store: true` | confirmed on the Android TV Play Store |
| YouTube Kids (TV) | `defunct: true` | dedicated TV app discontinued July 2024 |
| Showtime | `defunct: true` | standalone app shut down April 2024 (Paramount+) |
| Epix Now (Google TV pkg) | `defunct: true` | replaced by the unified MGM+ package |
| STARZ → LIONSGATE+ | rename | the package is STARZPLAY, rebranded 2022; US STARZ is a different package |
| Philo / AMC+ / Crave | unchanged | flagged packages are Fire-TV/non-Play variants — `play_store: false` was already correct |

Spot-check of 5 additional streaming entries (fubo, Vudu, Haystack, Sling, BritBox) found no further errors. JSON valid; all loader lint tests pass.