### PR TITLE
Tests: MockAdb error injection + launcher takeover coverage

### DIFF
--- a/v2/src-tauri/src/commands/health.rs
+++ b/v2/src-tauri/src/commands/health.rs
@@ -39,51 +39,7 @@ pub async fn health_report(
     state: State<'_, AppState>,
     serial: String,
 ) -> Result<HealthReport, String> {
-    let adb = state.adb_snapshot().await;
-    let (display_res, mem_res, thermal_res, df_res, audio_res, hwprops_res) = tokio::join!(
-        adb.shell(&serial, "dumpsys display"),
-        adb.shell(&serial, "dumpsys meminfo"),
-        adb.shell(&serial, "dumpsys thermalservice"),
-        adb.shell(&serial, "df -h /data"),
-        adb.shell(&serial, "dumpsys audio"),
-        adb.shell(&serial, "dumpsys hardware_properties"),
-    );
-    let display_out = display_res.map_err(|e| format!("dumpsys display: {e}"))?;
-    let mem_out = mem_res.map_err(|e| format!("dumpsys meminfo: {e}"))?;
-    // Thermal, storage, audio are best-effort — some Android builds restrict
-    // access; surfacing them as missing is better than failing the whole report.
-    let thermal_text = thermal_res.map(|o| o.stdout).unwrap_or_default();
-    let df_text = df_res.map(|o| o.stdout).unwrap_or_default();
-    let audio_text = audio_res.map(|o| o.stdout).unwrap_or_default();
-
-    let display = parse_display_mode(&display_out.stdout);
-    let ram = parse_meminfo_summary(&mem_out.stdout);
-    let storage = parse_storage_info(&df_text);
-    let temperature_c = parse_thermal_max_celsius(&thermal_text).or_else(|| {
-        parse_hardware_properties_temp(
-            &hwprops_res
-                .as_ref()
-                .map(|o| o.stdout.clone())
-                .unwrap_or_default(),
-        )
-    });
-    let audio_device = parse_active_audio_device(&audio_text);
-
-    let mut top_memory: Vec<MemoryEntry> = parse_total_pss_by_process(&mem_out.stdout)
-        .into_iter()
-        .map(|(package, mb)| MemoryEntry { package, mb })
-        .collect();
-    top_memory.sort_by(|a, b| b.mb.partial_cmp(&a.mb).unwrap_or(std::cmp::Ordering::Equal));
-    top_memory.truncate(20);
-
-    Ok(HealthReport {
-        display,
-        ram,
-        storage,
-        temperature_c,
-        audio_device,
-        top_memory,
-    })
+    health_report_for(state.inner(), &serial).await
 }
 
 /// `app_list_for_device` — return the merged app list for a given device type.
@@ -142,9 +98,8 @@ pub async fn report_all(state: State<'_, AppState>) -> Result<Vec<DeviceReport>,
     Ok(out)
 }
 
-/// Internal helper — same as `health_report` but takes `&AppState`. Lets
-/// `report_all` reuse the implementation without juggling Tauri's State
-/// lifetime constraints.
+/// Shared implementation for `health_report` and `report_all`. Takes
+/// `&AppState` so both callers avoid juggling Tauri's State lifetime.
 async fn health_report_for(state: &AppState, serial: &str) -> Result<HealthReport, String> {
     let adb = state.adb_snapshot().await;
     let (display_res, mem_res, thermal_res, df_res, audio_res, hwprops_res) = tokio::join!(

--- a/v2/src-tauri/src/commands/install.rs
+++ b/v2/src-tauri/src/commands/install.rs
@@ -63,6 +63,12 @@ pub struct RestartResult {
 /// USB-cable swap. Does not redownload — for that use `install_adb`.
 #[tauri::command]
 pub async fn restart_adb(state: State<'_, AppState>) -> Result<RestartResult, String> {
+    restart_adb_impl(state.inner()).await
+}
+
+/// Reusable implementation — callable from tests against an `AppState` without
+/// the `State<'_, T>` lifetime constraint.
+async fn restart_adb_impl(state: &AppState) -> Result<RestartResult, String> {
     let adb = state.adb_snapshot().await;
 
     // kill-server drops every TCP connection. USB devices re-enumerate on
@@ -157,5 +163,53 @@ pub async fn install_adb(state: State<'_, AppState>) -> Result<InstallResult, St
             path: None,
             message: e.to_string(),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::test_support::{state_with, MockAdb};
+
+    #[tokio::test]
+    async fn restart_adb_reports_failure_when_network_reconnect_fails() {
+        // Daemon restarts fine, but the previously-connected network device
+        // can't be reconnected — that's a user-visible failure, and the message
+        // must name the device and point at the recovery action.
+        let serial = "192.168.1.50:5555";
+        let mock = MockAdb::default()
+            .on_raw(
+                "devices",
+                &format!("List of devices attached\n{serial}\tdevice\n"),
+            )
+            .on_raw("start-server", "* daemon started successfully")
+            .on_raw_err("connect", "connection refused");
+        let state = state_with(mock);
+
+        let res = restart_adb_impl(&state).await.unwrap();
+
+        assert!(!res.ok);
+        assert!(
+            res.message.contains("Could not reconnect") && res.message.contains(serial),
+            "message should name the unreconnected device: {}",
+            res.message
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_adb_reports_failure_when_start_server_errors() {
+        // No network devices to reconnect, but start-server itself fails — the
+        // result must be a failure carrying the daemon's error text.
+        let mock = MockAdb::default().on_raw_err("start-server", "cannot bind to port 5037");
+        let state = state_with(mock);
+
+        let res = restart_adb_impl(&state).await.unwrap();
+
+        assert!(!res.ok);
+        assert!(
+            res.message.contains("cannot bind to port 5037"),
+            "message should surface the daemon error: {}",
+            res.message
+        );
     }
 }

--- a/v2/src-tauri/src/commands/launcher.rs
+++ b/v2/src-tauri/src/commands/launcher.rs
@@ -490,6 +490,142 @@ pub async fn channel_provider_disabled(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::test_support::{state_with, MockAdb};
+
+    #[tokio::test]
+    async fn set_launcher_first_strategy_wins_and_skips_the_rest() {
+        // Role API succeeds and the resolver confirms it — the fallback ladder
+        // (set-home-activity, query-activities, HOME-intent kick) must not run.
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Success")
+            .on_shell("resolve-activity", "com.example.launcher/.MainActivity");
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", false)
+            .await
+            .unwrap();
+
+        assert!(res.ok);
+        assert_eq!(res.strategy.as_deref(), Some("role_api"));
+        assert_eq!(
+            res.current_launcher.as_deref(),
+            Some("com.example.launcher")
+        );
+
+        let calls = log.lock().unwrap();
+        assert!(!calls.iter().any(|c| c.contains("set-home-activity")));
+        assert!(!calls.iter().any(|c| c.contains("query-activities")));
+        assert!(!calls.iter().any(|c| c.contains("am start")));
+    }
+
+    #[tokio::test]
+    async fn set_launcher_falls_back_to_set_home_activity_when_role_unsupported() {
+        // Build doesn't know the role command; the set-home-activity fallback
+        // takes over and verifies.
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Unknown command")
+            .on_shell("set-home-activity", "Success")
+            .on_shell("resolve-activity", "com.example.launcher/.MainActivity");
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", false)
+            .await
+            .unwrap();
+
+        assert!(res.ok);
+        assert_eq!(res.strategy.as_deref(), Some("set_home_activity"));
+
+        let calls = log.lock().unwrap();
+        assert!(calls.iter().any(|c| c.contains("add-role-holder")));
+        assert!(calls.iter().any(|c| c.contains("set-home-activity")));
+    }
+
+    #[tokio::test]
+    async fn set_launcher_reports_failure_with_reason_when_all_strategies_fail() {
+        // Role errors out, set-home-activity returns a real error, the resolver
+        // never names the target — the result should fail and surface why.
+        let mock = MockAdb::default()
+            .on_shell_err("add-role-holder", "secure connection refused")
+            .on_shell_failure("set-home-activity", "Error: Activity class does not exist");
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", false)
+            .await
+            .unwrap();
+
+        assert!(!res.ok);
+        assert_eq!(res.strategy, None);
+        let err = res.last_error.expect("a failure reason");
+        assert!(
+            err.contains("Activity class does not exist"),
+            "unhelpful failure message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_launcher_stock_takeover_reverts_when_it_does_not_verify() {
+        // Resolver always names the stock launcher, so the takeover never
+        // verifies — the stock launcher must be re-enabled (revert).
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Unknown command")
+            .on_shell_failure("set-home-activity", "Error: no such activity")
+            .on_shell("resolve-activity", "com.google.android.tvlauncher/.Home");
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", true)
+            .await
+            .unwrap();
+
+        assert!(!res.ok);
+        let calls = log.lock().unwrap();
+        assert!(calls
+            .iter()
+            .any(|c| c == "pm disable-user --user 0 com.google.android.tvlauncher"));
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "pm enable com.google.android.tvlauncher"),
+            "stock launcher should be re-enabled after a failed takeover"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_launcher_stock_takeover_does_not_revert_when_it_verifies() {
+        // Resolver reports the stock launcher until it is disabled, then the
+        // target — the takeover verifies, so no revert should be issued.
+        let mock = MockAdb::default()
+            .on_shell("add-role-holder", "Unknown command")
+            .on_shell_failure("set-home-activity", "Error: no such activity")
+            .on_shell_seq(
+                "resolve-activity",
+                &[
+                    "com.google.android.tvlauncher/.Home",
+                    "com.example.launcher/.MainActivity",
+                ],
+            );
+        let log = mock.shell_log();
+        let state = state_with(mock);
+
+        let res = set_default_launcher_impl(&state, "serial", "com.example.launcher", true)
+            .await
+            .unwrap();
+
+        assert!(res.ok);
+        assert_eq!(res.strategy.as_deref(), Some("disable_stock_takeover"));
+        let calls = log.lock().unwrap();
+        assert!(calls
+            .iter()
+            .any(|c| c == "pm disable-user --user 0 com.google.android.tvlauncher"));
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c == "pm enable com.google.android.tvlauncher"),
+            "no revert expected after a verified takeover"
+        );
+    }
 
     #[test]
     fn parses_home_handler_packages_from_resolveinfo() {

--- a/v2/src-tauri/src/commands/launcher.rs
+++ b/v2/src-tauri/src/commands/launcher.rs
@@ -367,7 +367,9 @@ pub async fn set_default_launcher_impl(
                 }
                 // Takeover didn't verify — put the stock launcher back the
                 // way we found it rather than leaving a half-applied state.
-                let _ = adb.shell(serial, &format!("pm enable {active}")).await;
+                if is_valid_package_name(&active) {
+                    let _ = adb.shell(serial, &format!("pm enable {active}")).await;
+                }
             }
         }
     }

--- a/v2/src-tauri/src/commands/mod.rs
+++ b/v2/src-tauri/src/commands/mod.rs
@@ -26,6 +26,25 @@ pub mod update;
 
 pub use state::AppState;
 
+/// Setting keys must match `[A-Za-z0-9._-]+` — all real Android setting keys
+/// do. Anything else (spaces, semicolons, `$`, backticks, …) would be
+/// interpolated verbatim into a `settings` command and re-parsed by the
+/// device shell. Shared by the tweaks writer and snapshot apply — one
+/// implementation so the security check can't drift.
+pub(crate) fn is_valid_setting_key(key: &str) -> bool {
+    !key.is_empty()
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// Single-quote a value for the device-side shell — the standard `'\''`
+/// idiom (same as `quote_path` in files.rs). Spaces and all shell
+/// metacharacters inside the value are inert once wrapped.
+pub(crate) fn quote_shell_arg(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
 /// Test-only ADB driver + state builder, shared across command unit tests.
 /// Lets a test stub `adb`/`shell` output by substring and run a command's
 /// reusable `_impl` against it without a real device.

--- a/v2/src-tauri/src/commands/mod.rs
+++ b/v2/src-tauri/src/commands/mod.rs
@@ -50,31 +50,98 @@ pub(crate) fn quote_shell_arg(s: &str) -> String {
 /// reusable `_impl` against it without a real device.
 #[cfg(test)]
 pub mod test_support {
-    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
 
-    use crate::adb::{AdbDriver, AdbOutput, AdbResult};
+    use crate::adb::{AdbDriver, AdbError, AdbOutput, AdbResult};
     use crate::engine::AppListBundle;
 
     use super::AppState;
 
+    /// One canned response. `Ok` returns it as stdout (exit 0); `Err` makes the
+    /// call return a typed `AdbError` so command error branches get exercised.
+    enum Reply {
+        Ok(String),
+        Err(String),
+    }
+
+    /// A substring rule plus its (possibly sequenced) responses. `cursor`
+    /// advances per matching call and sticks on the last reply, so a single
+    /// needle can hand back different outputs across calls — needed to model a
+    /// resolver whose answer changes after a `pm disable-user`.
+    struct Rule {
+        needle: String,
+        replies: Vec<Reply>,
+        cursor: AtomicUsize,
+    }
+
+    impl Rule {
+        fn single(needle: &str, reply: Reply) -> Self {
+            Self {
+                needle: needle.into(),
+                replies: vec![reply],
+                cursor: AtomicUsize::new(0),
+            }
+        }
+    }
+
     #[derive(Default)]
     pub struct MockAdb {
-        shell_rules: Vec<(String, String)>,
-        raw_rules: Vec<(String, String)>,
+        shell_rules: Vec<Rule>,
+        raw_rules: Vec<Rule>,
+        shell_log: Arc<Mutex<Vec<String>>>,
     }
 
     impl MockAdb {
         /// Return `stdout` for any `shell` whose command contains `needle`.
         pub fn on_shell(mut self, needle: &str, stdout: &str) -> Self {
-            self.shell_rules.push((needle.into(), stdout.into()));
+            self.shell_rules
+                .push(Rule::single(needle, Reply::Ok(stdout.into())));
+            self
+        }
+        /// Make matching `shell` calls fail with a typed `AdbError` carrying
+        /// `err_message` — the subprocess-failure branch (nonzero exit).
+        pub fn on_shell_err(mut self, needle: &str, err_message: &str) -> Self {
+            self.shell_rules
+                .push(Rule::single(needle, Reply::Err(err_message.into())));
+            self
+        }
+        /// Matching `shell` calls return Ok but with output that trips
+        /// `shell_reported_failure()` — how `pm`/`cmd` report errors without a
+        /// nonzero exit. Pass a `stdout` containing "Failure"/"Error". Distinct
+        /// name from `on_shell` keeps the intent legible at the call site.
+        pub fn on_shell_failure(self, needle: &str, stdout: &str) -> Self {
+            self.on_shell(needle, stdout)
+        }
+        /// Hand back `responses` in order for successive matching `shell` calls,
+        /// sticking on the last once exhausted.
+        pub fn on_shell_seq(mut self, needle: &str, responses: &[&str]) -> Self {
+            self.shell_rules.push(Rule {
+                needle: needle.into(),
+                replies: responses.iter().map(|s| Reply::Ok((*s).into())).collect(),
+                cursor: AtomicUsize::new(0),
+            });
             self
         }
         /// Return `stdout` for any `raw` whose joined args contain `needle`.
         pub fn on_raw(mut self, needle: &str, stdout: &str) -> Self {
-            self.raw_rules.push((needle.into(), stdout.into()));
+            self.raw_rules
+                .push(Rule::single(needle, Reply::Ok(stdout.into())));
             self
+        }
+        /// Make matching `raw` calls fail with a typed `AdbError`.
+        pub fn on_raw_err(mut self, needle: &str, err_message: &str) -> Self {
+            self.raw_rules
+                .push(Rule::single(needle, Reply::Err(err_message.into())));
+            self
+        }
+        /// Shared handle to the recorded `shell` command log. Grab it before
+        /// moving the mock into `state_with`, then assert on side-effect
+        /// commands (e.g. that a revert `pm enable` was — or wasn't — issued).
+        pub fn shell_log(&self) -> Arc<Mutex<Vec<String>>> {
+            Arc::clone(&self.shell_log)
         }
     }
 
@@ -86,24 +153,36 @@ pub mod test_support {
         })
     }
 
+    /// First-match-wins across rules in registration order, advancing the
+    /// matched rule's cursor. Unmatched calls succeed with empty stdout, so
+    /// existing tests that register no rules keep their default behavior.
+    fn reply_for(rules: &[Rule], haystack: &str) -> AdbResult<AdbOutput> {
+        for rule in rules {
+            if haystack.contains(rule.needle.as_str()) {
+                let idx = rule
+                    .cursor
+                    .fetch_add(1, Ordering::Relaxed)
+                    .min(rule.replies.len() - 1);
+                return match &rule.replies[idx] {
+                    Reply::Ok(out) => ok(out.clone()),
+                    Reply::Err(msg) => Err(AdbError::NonZeroExit {
+                        code: Some(1),
+                        stderr: msg.clone(),
+                    }),
+                };
+            }
+        }
+        ok(String::new())
+    }
+
     #[async_trait]
     impl AdbDriver for MockAdb {
         async fn raw(&self, args: &[&str]) -> AdbResult<AdbOutput> {
-            let joined = args.join(" ");
-            for (needle, out) in &self.raw_rules {
-                if joined.contains(needle.as_str()) {
-                    return ok(out.clone());
-                }
-            }
-            ok(String::new())
+            reply_for(&self.raw_rules, &args.join(" "))
         }
         async fn shell(&self, _serial: &str, command: &str) -> AdbResult<AdbOutput> {
-            for (needle, out) in &self.shell_rules {
-                if command.contains(needle.as_str()) {
-                    return ok(out.clone());
-                }
-            }
-            ok(String::new())
+            self.shell_log.lock().unwrap().push(command.to_string());
+            reply_for(&self.shell_rules, command)
         }
     }
 

--- a/v2/src-tauri/src/commands/recovery.rs
+++ b/v2/src-tauri/src/commands/recovery.rs
@@ -48,6 +48,13 @@ pub async fn panic_recovery(
     let mut failed = Vec::new();
 
     for pkg in &disabled {
+        if !crate::engine::is_valid_package_name(pkg) {
+            failed.push(RecoveryFailure {
+                package: pkg.clone(),
+                error: "invalid package name".to_string(),
+            });
+            continue;
+        }
         match adb.shell(&serial, &format!("pm enable {pkg}")).await {
             Ok(out) if !out.shell_reported_failure() => {
                 restored.push(pkg.clone());

--- a/v2/src-tauri/src/commands/snapshot.rs
+++ b/v2/src-tauri/src/commands/snapshot.rs
@@ -10,8 +10,9 @@ use crate::engine::snapshot::{
     compute_apply_plan, tracked_setting_keys, ApplyPlanInputs, Snapshot, SnapshotApplyPlan,
     SCHEMA_VERSION,
 };
+use crate::engine::{is_never_disable, is_valid_package_name};
 
-use super::AppState;
+use super::{is_valid_setting_key, quote_shell_arg, AppState};
 
 /// Read the device's current values for the tracked setting keys, keyed the
 /// same way snapshots store them (`"<ns>.<key>"`). Used so apply-plans can
@@ -330,6 +331,35 @@ pub struct ApplyResult {
     pub summary: String,
 }
 
+/// Execute the disable portion of an apply-plan. Extracted for testability.
+/// Returns `(packages_disabled, packages_failed)`.
+async fn disable_from_plan(
+    adb: &dyn crate::adb::AdbDriver,
+    serial: &str,
+    packages_to_disable: &[String],
+) -> (Vec<String>, Vec<String>) {
+    let mut packages_disabled = Vec::new();
+    let mut packages_failed = Vec::new();
+    for pkg in packages_to_disable {
+        if !is_valid_package_name(pkg) {
+            packages_failed.push(format!("{pkg:?} (invalid package name in snapshot)"));
+            continue;
+        }
+        if is_never_disable(pkg) {
+            packages_failed.push(format!("{pkg} (refused: brick risk)"));
+            continue;
+        }
+        let cmd = format!("pm disable-user --user 0 {pkg}");
+        match adb.shell(serial, &cmd).await {
+            Ok(out) if !out.shell_reported_failure() => {
+                packages_disabled.push(pkg.clone());
+            }
+            _ => packages_failed.push(pkg.clone()),
+        }
+    }
+    (packages_disabled, packages_failed)
+}
+
 /// `apply_snapshot` — actually run the previewed plan against the device.
 /// Honors commitment #7 (reversibility): only `pm disable-user` writes,
 /// never re-enables a currently-enabled package the snapshot didn't list.
@@ -381,24 +411,8 @@ pub async fn apply_snapshot(
     );
 
     // 1. Disable packages from the plan (additive only — never re-enable).
-    // Defense-in-depth: refuse to disable anything on the NEVER_DISABLE list
-    // even if a malformed snapshot lists it. Categorized as "failed" so the
-    // UI surfaces it instead of silently ignoring.
-    let mut packages_disabled = Vec::new();
-    let mut packages_failed = Vec::new();
-    for pkg in &plan.packages_to_disable {
-        if crate::engine::is_never_disable(pkg) {
-            packages_failed.push(format!("{pkg} (refused: brick risk)"));
-            continue;
-        }
-        let cmd = format!("pm disable-user --user 0 {pkg}");
-        match adb.shell(&serial, &cmd).await {
-            Ok(out) if !out.shell_reported_failure() => {
-                packages_disabled.push(pkg.clone());
-            }
-            _ => packages_failed.push(pkg.clone()),
-        }
-    }
+    let (packages_disabled, packages_failed) =
+        disable_from_plan(adb.as_ref(), &serial, &plan.packages_to_disable).await;
 
     // 2. Set launcher if requested.
     let mut launcher_set = false;
@@ -441,14 +455,19 @@ pub async fn apply_snapshot(
             settings_failed.push(format!("{k}: malformed key (expected ns.subkey)"));
             continue;
         };
-        // Snapshots are user-editable files on disk; reject values that could
-        // break out of the shell command, matching write_setting's guard.
-        if v.contains(';') || v.contains('|') || v.contains('&') {
-            settings_failed.push(format!("{k}: value contains shell metacharacters"));
+        if !matches!(ns, "global" | "secure" | "system") {
+            settings_failed.push(format!("{k}: unrecognized namespace"));
             continue;
         }
+        if !is_valid_setting_key(key) {
+            settings_failed.push(format!("{k}: key contains invalid characters"));
+            continue;
+        }
+        // Single-quote the value so shell metacharacters inside it are inert;
+        // legitimate content (numbers, spaces, device names) passes through.
+        let quoted_v = quote_shell_arg(v);
         match adb
-            .shell(&serial, &format!("settings put {ns} {key} {v}"))
+            .shell(&serial, &format!("settings put {ns} {key} {quoted_v}"))
             .await
         {
             Ok(out) if !out.shell_reported_failure() => settings_written.push(k.clone()),
@@ -478,7 +497,7 @@ pub async fn apply_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use super::current_settings_map;
+    use super::{current_settings_map, disable_from_plan};
     use crate::commands::test_support::MockAdb;
 
     #[tokio::test]
@@ -508,5 +527,25 @@ mod tests {
         );
         // "null" line is dropped, not stored.
         assert!(!map.contains_key("global.hdmi_control_auto_wakeup_enabled"));
+    }
+
+    #[tokio::test]
+    async fn disable_from_plan_records_invalid_name_without_aborting() {
+        // A snapshot file might contain a malformed or injected package name.
+        // The invalid entry must go to packages_failed; valid ones still run.
+        let mock = MockAdb::default(); // empty stdout = pm success for all calls
+        let pkgs = vec![
+            "com.valid.package".to_string(),
+            "evil; reboot".to_string(),
+            "com.another.valid".to_string(),
+        ];
+        let (disabled, failed) = disable_from_plan(&mock, "serial", &pkgs).await;
+        assert_eq!(disabled, ["com.valid.package", "com.another.valid"]);
+        assert_eq!(failed.len(), 1, "exactly the invalid entry should fail");
+        assert!(
+            failed[0].contains("invalid package name"),
+            "failure reason missing from message: {}",
+            failed[0]
+        );
     }
 }

--- a/v2/src-tauri/src/commands/snapshot.rs
+++ b/v2/src-tauri/src/commands/snapshot.rs
@@ -548,4 +548,21 @@ mod tests {
             failed[0]
         );
     }
+
+    #[tokio::test]
+    async fn disable_from_plan_records_pm_failure_without_aborting() {
+        // `pm disable-user` reports failure via stdout while `adb shell` still
+        // exits 0 — that package must land in packages_failed, the others must
+        // still succeed.
+        let mock = MockAdb::default()
+            .on_shell_failure("com.fails.pkg", "Failure [not installed for user 0]");
+        let pkgs = vec![
+            "com.ok.one".to_string(),
+            "com.fails.pkg".to_string(),
+            "com.ok.two".to_string(),
+        ];
+        let (disabled, failed) = disable_from_plan(&mock, "serial", &pkgs).await;
+        assert_eq!(disabled, ["com.ok.one", "com.ok.two"]);
+        assert_eq!(failed, ["com.fails.pkg"]);
+    }
 }

--- a/v2/src-tauri/src/commands/tuning.rs
+++ b/v2/src-tauri/src/commands/tuning.rs
@@ -4,7 +4,7 @@
 use serde::Serialize;
 use tauri::State;
 
-use super::AppState;
+use super::{is_valid_setting_key, quote_shell_arg, AppState};
 
 /// Snapshot of all the settings the Tweaks UI reads/writes. Matches the keys
 /// in `engine::snapshot::tracked_setting_keys` so a snapshot save captures
@@ -85,15 +85,16 @@ fn build_setting_command(namespace: &str, key: &str, value: &str) -> Result<Stri
             "namespace must be global/secure/system, got {namespace}"
         ));
     }
+    if !is_valid_setting_key(key) {
+        return Err(format!("key contains invalid characters: {key:?}"));
+    }
     if value.is_empty() {
         return Ok(format!("settings delete {namespace} {key}"));
     }
-    // Settings values in practice are numbers or short identifiers; reject
-    // anything that could break out of the shell quoting.
-    if value.contains(';') || value.contains('|') || value.contains('&') {
-        return Err("value contains shell metacharacters".to_string());
-    }
-    Ok(format!("settings put {namespace} {key} {value}"))
+    Ok(format!(
+        "settings put {namespace} {key} {}",
+        quote_shell_arg(value)
+    ))
 }
 
 /// `write_setting` — `settings put <namespace> <key> <value>`. Pass an empty
@@ -218,14 +219,14 @@ mod tests {
     use super::build_setting_command;
 
     #[test]
-    fn builds_put_for_valid_namespaces() {
+    fn builds_put_with_quoted_value() {
         assert_eq!(
             build_setting_command("global", "window_animation_scale", "0.5").unwrap(),
-            "settings put global window_animation_scale 0.5"
+            "settings put global window_animation_scale '0.5'"
         );
         assert_eq!(
             build_setting_command("secure", "match_content_frame_rate", "2").unwrap(),
-            "settings put secure match_content_frame_rate 2"
+            "settings put secure match_content_frame_rate '2'"
         );
     }
 
@@ -238,10 +239,39 @@ mod tests {
     }
 
     #[test]
-    fn rejects_bad_namespace_and_metacharacters() {
+    fn rejects_bad_namespace_and_bad_key() {
         assert!(build_setting_command("evil", "k", "1").is_err());
-        assert!(build_setting_command("global", "k", "1; rm -rf /").is_err());
-        assert!(build_setting_command("global", "k", "a|b").is_err());
-        assert!(build_setting_command("global", "k", "a&b").is_err());
+        assert!(build_setting_command("global", "x; reboot", "1").is_err());
+        assert!(build_setting_command("global", "x`whoami`", "1").is_err());
+        assert!(build_setting_command("global", "$(reboot)", "1").is_err());
+        assert!(build_setting_command("global", "", "1").is_err());
+    }
+
+    #[test]
+    fn value_quoting_handles_spaces_and_single_quotes() {
+        // Spaces in values (e.g. device names) must be quoted, not rejected.
+        let cmd = build_setting_command("global", "device_name", "My Shield TV").unwrap();
+        assert!(
+            cmd.contains("'My Shield TV'"),
+            "spaces in value must be single-quoted: {cmd}"
+        );
+
+        // Single quotes inside values use the standard `'\''` idiom.
+        let cmd = build_setting_command("secure", "device_name", "it's").unwrap();
+        assert!(
+            cmd.contains(r"'it'\''s'"),
+            "embedded single-quote must use the backslash idiom: {cmd}"
+        );
+    }
+
+    #[test]
+    fn value_metacharacters_are_quoted_not_rejected() {
+        // Values containing shell metacharacters are now quoted rather than
+        // rejected — the device shell cannot interpret them inside single quotes.
+        assert!(build_setting_command("global", "k", "1; rm -rf /").is_ok());
+        assert!(build_setting_command("global", "k", "a|b").is_ok());
+        assert!(build_setting_command("global", "k", "a&b").is_ok());
+        assert!(build_setting_command("global", "k", "$(whoami)").is_ok());
+        assert!(build_setting_command("global", "k", "`id`").is_ok());
     }
 }


### PR DESCRIPTION
Audit follow-up (stacked on #64 — auto-retargets to main when that merges).

MockAdb could only ever return success, so no command error branch was tested. It now supports typed adb errors, `pm`-style "Failure" stdout, **sequenced responses** (needed to model the HOME resolver changing its answer after a `pm disable-user`), and a shell-command log for asserting side effects.

8 new tests, the headline being the **launcher takeover strategy ladder** — the most stateful logic in the app, previously untested:
- first strategy wins → fallbacks provably don't run
- role API unsupported → falls back to set-home-activity
- everything fails → failure reason is surfaced
- stock-launcher takeover **reverts (`pm enable`) exactly when verification fails**, and provably doesn't when it succeeds

Plus `disable_from_plan` pm-failure accounting and both `restart_adb` failure paths (new `restart_adb_impl` seam, matching the existing `_impl` convention — no behavior change).

149 tests pass; clippy `--all-targets` clean.