### PR TITLE
Fix critical bugs from the codebase audit

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -45,8 +45,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Get the latest version tag
-LATEST_TAG=$(git tag --list 'v*.*.*' --sort=-v:refname | head -1)
+# Get the latest v1 version tag. Strictly vX.Y.Z only — the glob 'v*.*.*'
+# also matches v2's tag namespace (v2-2.0.0-beta.N), which version-sorts above
+# every v1 tag and would make this script bump from a v2 version.
+LATEST_TAG=$(git tag --list --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
 if [ -z "$LATEST_TAG" ]; then
     NEW_VERSION="v${INITIAL_VERSION}"

--- a/v2/src-tauri/src/adb/driver.rs
+++ b/v2/src-tauri/src/adb/driver.rs
@@ -74,6 +74,14 @@ pub trait AdbDriver: Send + Sync {
     /// Run `adb <args...>` (no `-s` prefix).
     async fn raw(&self, args: &[&str]) -> AdbResult<AdbOutput>;
 
+    /// Run `adb <args...>` with a transfer-sized timeout — for `pull` / `push`
+    /// / `install`, which stream whole files and legitimately take minutes on
+    /// big payloads (the standard timeout would kill them mid-transfer).
+    /// Default delegates to `raw` so mocks need no extra wiring.
+    async fn raw_transfer(&self, args: &[&str]) -> AdbResult<AdbOutput> {
+        self.raw(args).await
+    }
+
     /// Run `adb -s <serial> shell <command>`.
     async fn shell(&self, serial: &str, command: &str) -> AdbResult<AdbOutput>;
 
@@ -126,6 +134,10 @@ impl SubprocessAdb {
     }
 
     async fn run(&self, args: &[&str]) -> AdbResult<AdbOutput> {
+        self.run_with_timeout(args, self.command_timeout).await
+    }
+
+    async fn run_with_timeout(&self, args: &[&str], dur: Duration) -> AdbResult<AdbOutput> {
         if !self.binary.exists() {
             return Err(AdbError::BinaryMissing {
                 path: self.binary.display().to_string(),
@@ -139,12 +151,12 @@ impl SubprocessAdb {
         super::hide_console_window(&mut cmd);
         let fut = cmd.output();
 
-        let output = match timeout(self.command_timeout, fut).await {
+        let output = match timeout(dur, fut).await {
             Ok(r) => r?,
             Err(_) => {
                 warn!(?args, "adb timeout");
                 return Err(AdbError::Timeout {
-                    seconds: self.command_timeout.as_secs(),
+                    seconds: dur.as_secs(),
                 });
             }
         };
@@ -178,10 +190,18 @@ impl SubprocessAdb {
     }
 }
 
+/// Ceiling for file transfers: long enough for multi-GB pulls over slow Wi-Fi,
+/// short enough that a genuinely hung adb still surfaces as an error.
+const TRANSFER_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
 #[async_trait]
 impl AdbDriver for SubprocessAdb {
     async fn raw(&self, args: &[&str]) -> AdbResult<AdbOutput> {
         self.run(args).await
+    }
+
+    async fn raw_transfer(&self, args: &[&str]) -> AdbResult<AdbOutput> {
+        self.run_with_timeout(args, TRANSFER_TIMEOUT).await
     }
 
     async fn shell(&self, serial: &str, command: &str) -> AdbResult<AdbOutput> {

--- a/v2/src-tauri/src/commands/backup.rs
+++ b/v2/src-tauri/src/commands/backup.rs
@@ -97,7 +97,7 @@ async fn pull_apks(
     for remote in remotes {
         let local = dest.join(backup_file_name(package, version, remote, split));
         let local_str = local.display().to_string();
-        adb.raw(&["-s", serial, "pull", remote, &local_str])
+        adb.raw_transfer(&["-s", serial, "pull", remote, &local_str])
             .await
             .map_err(|e| format!("pull {remote}: {e}"))?;
         locals.push(local);
@@ -209,7 +209,7 @@ pub async fn clone_app(
         let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
 
         let out = adb
-            .raw(&args_ref)
+            .raw_transfer(&args_ref)
             .await
             .map_err(|e| format!("adb install: {e}"))?;
         let combined = out.combined().trim().to_string();

--- a/v2/src-tauri/src/commands/devices.rs
+++ b/v2/src-tauri/src/commands/devices.rs
@@ -111,14 +111,24 @@ pub async fn connect_device(
         .raw(&["connect", &target])
         .await
         .map_err(|e| format!("adb connect: {e}"))?;
-    Ok(ConnectResult {
-        ok: out.success(),
-        message: if out.stdout.is_empty() {
-            out.stderr
+    Ok(connect_result_from(&out))
+}
+
+/// `adb connect` exits 0 even on "failed to connect", so classify by output
+/// text (same rule as scan_network). Unauthorized counts as ok — the device
+/// is connected and waiting for the user to approve this computer on the TV.
+fn connect_result_from(out: &crate::adb::AdbOutput) -> ConnectResult {
+    use super::scan::{classify_connect_output, ConnectOutcome};
+    let combined = format!("{}\n{}", out.stdout, out.stderr).trim().to_string();
+    let outcome = classify_connect_output(&combined);
+    ConnectResult {
+        ok: outcome != ConnectOutcome::Failed,
+        message: if outcome == ConnectOutcome::Unauthorized {
+            format!("{combined} — approve this computer on the TV, then refresh.")
         } else {
-            out.stdout
+            combined
         },
-    })
+    }
 }
 
 /// `disconnect_device` — `adb disconnect <serial>`.
@@ -187,15 +197,13 @@ pub async fn pair_device(
         .raw(&["connect", &connect_target])
         .await
         .map_err(|e| format!("adb connect after pair: {e}"))?;
-    let ok = connect_out.success();
-    let connect_msg = if connect_out.stdout.is_empty() {
-        connect_out.stderr
-    } else {
-        connect_out.stdout
-    };
+    let connect_result = connect_result_from(&connect_out);
     Ok(ConnectResult {
-        ok,
-        message: format!("Paired. Connect to {connect_target}: {connect_msg}"),
+        ok: connect_result.ok,
+        message: format!(
+            "Paired. Connect to {connect_target}: {}",
+            connect_result.message
+        ),
     })
 }
 

--- a/v2/src-tauri/src/commands/files.rs
+++ b/v2/src-tauri/src/commands/files.rs
@@ -110,7 +110,7 @@ pub async fn pull_file(
     let adb = state.adb_snapshot().await;
     // `adb pull` takes the remote path as a plain argument — no device-side
     // shell involved, so no quoting needed (spaces and specials are fine).
-    adb.raw(&["-s", &serial, "pull", &remote, &local_str])
+    adb.raw_transfer(&["-s", &serial, "pull", &remote, &local_str])
         .await
         .map_err(|e| format!("pull {remote}: {e}"))?;
     Ok(FileTransferResult {
@@ -141,7 +141,7 @@ pub async fn push_file(
     let remote = format!("{}/{}", remote_dir.trim_end_matches('/'), file_name);
 
     let adb = state.adb_snapshot().await;
-    adb.raw(&["-s", &serial, "push", &local_path, &remote])
+    adb.raw_transfer(&["-s", &serial, "push", &local_path, &remote])
         .await
         .map_err(|e| format!("push {file_name}: {e}"))?;
     Ok(FileTransferResult {
@@ -179,11 +179,11 @@ pub async fn copy_file_to_device(
     let adb = state.adb_snapshot().await;
 
     let result = async {
-        adb.raw(&["-s", &source_serial, "pull", &remote, &temp_str])
+        adb.raw_transfer(&["-s", &source_serial, "pull", &remote, &temp_str])
             .await
             .map_err(|e| format!("pull {remote}: {e}"))?;
         let dest = format!("{}/{file_name}", target_dir.trim_end_matches('/'));
-        adb.raw(&["-s", &target_serial, "push", &temp_str, &dest])
+        adb.raw_transfer(&["-s", &target_serial, "push", &temp_str, &dest])
             .await
             .map_err(|e| format!("push to {target_serial}: {e}"))?;
         Ok::<FileTransferResult, String>(FileTransferResult {

--- a/v2/src-tauri/src/commands/scan.rs
+++ b/v2/src-tauri/src/commands/scan.rs
@@ -29,7 +29,7 @@ pub struct ScanResult {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-enum ConnectOutcome {
+pub(crate) enum ConnectOutcome {
     Connected,
     /// Device reachable but this host's ADB key isn't approved yet. The
     /// device is still added to `adb devices` (as `unauthorized`), so this
@@ -42,7 +42,7 @@ enum ConnectOutcome {
 /// combined streams rather than the exit code, since `adb connect` exits 0
 /// even on "failed to authenticate" / "failed to connect" with current
 /// platform-tools, and exit-code conventions vary across versions.
-fn classify_connect_output(combined: &str) -> ConnectOutcome {
+pub(crate) fn classify_connect_output(combined: &str) -> ConnectOutcome {
     let s = combined.to_lowercase();
     if s.contains("failed to authenticate") {
         ConnectOutcome::Unauthorized

--- a/v2/src-tauri/src/commands/sideload.rs
+++ b/v2/src-tauri/src/commands/sideload.rs
@@ -46,7 +46,7 @@ pub async fn install_apk(
     let args_ref: Vec<&str> = args.iter().map(String::as_str).collect();
 
     let out = adb
-        .raw(&args_ref)
+        .raw_transfer(&args_ref)
         .await
         .map_err(|e| format!("adb install: {e}"))?;
     let combined = if out.stdout.trim().is_empty() {

--- a/v2/src/lib/demo-mock.ts
+++ b/v2/src/lib/demo-mock.ts
@@ -12,6 +12,7 @@
 // real build.
 
 import demoApps from "./demo-apps.json";
+import pkg from "../../package.json";
 import type {
   AppEntry,
   Device,
@@ -207,9 +208,10 @@ function handle(cmd: string, args: Record<string, unknown>): unknown {
     case "adb_status":
       return { available: true, path: "/opt/homebrew/bin/adb", last_probe: "2026-06-02T14:40:00Z" };
     case "check_for_update":
+      // Real version so screenshots never show a stale header badge.
       return {
-        current: "0.1.0-beta.9",
-        latest: "0.1.0-beta.9",
+        current: pkg.version,
+        latest: pkg.version,
         update_available: false,
         url: "https://github.com/bryanroscoe/shield_optimizer/releases",
       };

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -102,6 +102,10 @@
   let trimMessage = $state("");
 
   let launchers = $state<LauncherStatus[]>([]);
+  // "Loaded" flags track load *attempts* — an empty result is a valid loaded
+  // state. Guarding the lazy-load effect on `length === 0` instead re-fetches
+  // forever when a list is legitimately empty (e.g. zero snapshots).
+  let launchersLoaded = $state(false);
   let currentLauncher = $state<CurrentLauncher | null>(null);
   let channelDisabled = $state<boolean | null>(null);
   let launcherLoading = $state(false);
@@ -110,6 +114,7 @@
   let launcherActionMessage = $state("");
 
   let apps = $state<AppEntry[]>([]);
+  let appsLoaded = $state(false);
   let appsLoading = $state(false);
   let appsErr = $state<string | null>(null);
   /// package → 'enabled' | 'disabled' | 'missing' — refreshed alongside the app list.
@@ -158,6 +163,7 @@
   let cloneBusy = $state(false);
 
   let snapshots = $state<SnapshotFile[]>([]);
+  let snapshotsLoaded = $state(false);
   let snapshotsErr = $state<string | null>(null);
   let saveBusy = $state(false);
   let saveResult = $state<string>("");
@@ -180,6 +186,9 @@
   let discoveredApks = $state<import("$lib/types").DiscoveredApk[]>([]);
   let discoveredFolder = $state<string | null>(null);
   let discoveryBusy = $state(false);
+  /// The remembered-folder auto-scan runs at most once per device visit —
+  /// an empty or failing folder must not re-trigger it.
+  let apkAutoScanAttempted = $state(false);
 
   // Header actions: reboot menu visibility, disconnect/reboot status, recovery.
   let rebootMenuOpen = $state(false);
@@ -352,6 +361,7 @@
       launcherErr = String(e);
     } finally {
       launcherLoading = false;
+      launchersLoaded = true;
     }
   }
 
@@ -370,6 +380,7 @@
       appsErr = String(e);
     } finally {
       appsLoading = false;
+      appsLoaded = true;
     }
     loadOtherPackages();
     loadAppMemory();
@@ -915,6 +926,8 @@
       snapshots = await api.listSnapshots();
     } catch (e) {
       snapshotsErr = String(e);
+    } finally {
+      snapshotsLoaded = true;
     }
   }
 
@@ -951,6 +964,21 @@
     }
   }
 
+  /// Bulk mutations (snapshot apply, panic recovery) change package and
+  /// launcher state behind the App List / Optimize / Launcher caches — re-sync
+  /// them the same way executeOptimize does after a run. A partial failure
+  /// still changed state, so callers resync unconditionally.
+  async function resyncAfterBulkChange() {
+    optimizePlan = null;
+    launchersLoaded = false;
+    if (apps.length === 0) return;
+    try {
+      appStates = await fetchAppStates(apps.map((a) => a.package));
+    } catch {
+      appsLoaded = false; // fall back to the lazy reload next tab visit
+    }
+  }
+
   async function applySnapshot() {
     if (!previewPath || !preview) return;
     const total =
@@ -968,6 +996,7 @@
     } finally {
       applyBusy = false;
     }
+    await resyncAfterBulkChange();
   }
 
   async function runRecovery() {
@@ -982,6 +1011,7 @@
     } finally {
       recoveryBusy = false;
     }
+    await resyncAfterBulkChange();
   }
 
   async function rebootDevice(mode: RebootMode) {
@@ -1503,14 +1533,15 @@
     if (activeTab === "health") {
       if (report === null && !reportLoading && !reportErr) loadHealth();
       // Preload catalog so the memory table can show risk tiers.
-      if (apps.length === 0 && !appsLoading && !appsErr) loadApps();
+      if (!appsLoaded && !appsLoading) loadApps();
     }
-    if (activeTab === "launcher" && launchers.length === 0 && !launcherLoading && !launcherErr) loadLauncher();
-    if (activeTab === "apps" && apps.length === 0 && !appsLoading && !appsErr) loadApps();
+    if (activeTab === "launcher" && !launchersLoaded && !launcherLoading) loadLauncher();
+    if (activeTab === "apps" && !appsLoaded && !appsLoading) loadApps();
     if (activeTab === "tweaks" && tweaks === null && !tweaksLoading && !tweaksErr) loadTweaks();
     if (activeTab === "files" && filesEntries === null && !filesLoading && !filesErr) loadFiles(filesPath);
-    if (activeTab === "snapshot" && snapshots.length === 0) loadSnapshots();
-    if (activeTab === "sideload" && discoveredApks.length === 0 && !discoveryBusy) {
+    if (activeTab === "snapshot" && !snapshotsLoaded) loadSnapshots();
+    if (activeTab === "sideload" && !apkAutoScanAttempted) {
+      apkAutoScanAttempted = true;
       const last = localStorage.getItem("shieldopt.lastApkFolder");
       if (last) scanApkFolder(last);
     }
@@ -1529,13 +1560,13 @@
     activeTab = "overview";
     device = null; deviceErr = null;
     report = null; reportErr = null; reportLastRefreshed = null; safetyMap = {};
-    launchers = []; currentLauncher = null; channelDisabled = null;
+    launchers = []; launchersLoaded = false; currentLauncher = null; channelDisabled = null;
     launcherErr = null; launcherActionMessage = "";
-    apps = []; appsErr = null; appStates = {}; appActionMessage = "";
+    apps = []; appsLoaded = false; appsErr = null; appStates = {}; appActionMessage = "";
     otherPackages = []; appMemory = {}; appUsage = {}; appSearch = ""; hideNotInstalled = true; showSystemOthers = false;
     clonePkg = null; cloneTargets = [];
-    snapshots = []; snapshotsErr = null; preview = null; previewPath = null; previewErr = null; saveResult = "";
-    sideloadResult = ""; sideloadHint = null; sideloadResultPath = null; discoveredApks = []; discoveredFolder = null; apkInstallState = {};
+    snapshots = []; snapshotsLoaded = false; snapshotsErr = null; preview = null; previewPath = null; previewErr = null; saveResult = "";
+    sideloadResult = ""; sideloadHint = null; sideloadResultPath = null; discoveredApks = []; discoveredFolder = null; apkInstallState = {}; apkAutoScanAttempted = false;
     headerActionMsg = ""; recoveryResult = null; recoveryErr = null; screenshot = null;
     renaming = false; renameValue = "";
     remoteEcho = ""; remoteMessage = ""; remoteBuffer = "";


### PR DESCRIPTION
Recreated #62 (GitHub closed it when its stacked base branch was deleted on merge — same branch, same content).

Six fixes from the full-codebase review:

- **Infinite IPC re-fetch loop** — the tab lazy-loader used `length === 0` as "not loaded yet", so an empty snapshot list (every new user) or an empty APK folder re-fetched forever. Now guarded by explicit loaded/attempted flags. Likely the cause of the runaway memory growth seen in long sessions.
- **ADB transfer timeout** — every ADB call shared a 30s timeout, guaranteeing failure for large APK backups, clones, and file-manager pulls/pushes. Transfers now run through a new `raw_transfer` driver method with a 15-minute ceiling.
- **Connect false-success** — `adb connect` exits 0 even on "failed to connect"; Connect IP and PIN pairing now classify the output text and unauthorized connections hint at the on-TV approval step.
- **State parity** — snapshot apply and panic recovery now re-sync the App List / Optimize / Launcher caches.
- **Screenshot version badge** — demo fixtures read the real version from package.json.
- **v1 release.sh** — the latest-tag glob matched `v2-*` tags; now strictly `vX.Y.Z`.