### PR TITLE
Dead-code sweep from the codebase audit

### DIFF
--- a/v2/src-tauri/Cargo.lock
+++ b/v2/src-tauri/Cargo.lock
@@ -3508,7 +3508,6 @@ dependencies = [
 name = "shield-optimizer-v2"
 version = "2.0.0-beta.12"
 dependencies = [
- "anyhow",
  "async-trait",
  "axmldecoder",
  "base64 0.22.1",

--- a/v2/src-tauri/Cargo.toml
+++ b/v2/src-tauri/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["process", "io-util", "time", "macros", "rt-multi-thread", "sync", "fs"] }
 
 # Error handling
-anyhow = "1"
 thiserror = "1"
 
 # Parsing

--- a/v2/src-tauri/src/adb/driver.rs
+++ b/v2/src-tauri/src/adb/driver.rs
@@ -119,20 +119,6 @@ impl SubprocessAdb {
         discover_adb_binary().map(Self::new)
     }
 
-    /// Back-compat alias for the old PATH-only discovery.
-    pub fn from_path() -> Option<Self> {
-        Self::discover()
-    }
-
-    pub fn binary(&self) -> &PathBuf {
-        &self.binary
-    }
-
-    pub fn with_timeout(mut self, dur: Duration) -> Self {
-        self.command_timeout = dur;
-        self
-    }
-
     async fn run(&self, args: &[&str]) -> AdbResult<AdbOutput> {
         self.run_with_timeout(args, self.command_timeout).await
     }

--- a/v2/src-tauri/src/adb/mod.rs
+++ b/v2/src-tauri/src/adb/mod.rs
@@ -32,9 +32,9 @@ pub use driver::{AdbDriver, AdbError, AdbOutput, AdbResult, SubprocessAdb};
 pub use install::{adb_path_in_install_root, install_platform_tools, InstallError};
 pub use parse::{
     parse_active_audio_device, parse_device_list, parse_disabled_packages_output,
-    parse_display_mode, parse_dumpsys_meminfo, parse_hardware_properties_temp,
-    parse_installed_packages_output, parse_ls_output, parse_meminfo_summary, parse_storage_info,
-    parse_thermal_max_celsius, parse_total_pss_by_process, parse_usage_stats, AppUsage,
-    DisplayMode, FileEntry, RamInfo, StorageInfo,
+    parse_display_mode, parse_hardware_properties_temp, parse_installed_packages_output,
+    parse_ls_output, parse_meminfo_summary, parse_storage_info, parse_thermal_max_celsius,
+    parse_total_pss_by_process, parse_usage_stats, AppUsage, DisplayMode, FileEntry, RamInfo,
+    StorageInfo,
 };
 pub use scan::{local_subnet_prefix, scan_subnet, ScanHit};

--- a/v2/src-tauri/src/adb/parse.rs
+++ b/v2/src-tauri/src/adb/parse.rs
@@ -129,7 +129,7 @@ pub fn parse_disabled_packages_output(output: &str) -> Vec<String> {
 ///
 /// Per v1's Get-AppMemoryMap learnings: per-process query (`dumpsys meminfo <pkg>`)
 /// is unreliable across Android versions; the system-wide section is robust.
-pub fn parse_dumpsys_meminfo(meminfo: &str) -> HashMap<String, f64> {
+fn parse_dumpsys_meminfo(meminfo: &str) -> HashMap<String, f64> {
     static ROW: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"^\s*([\d,]+)K:\s+([a-zA-Z0-9_.]+)").unwrap());
 

--- a/v2/src-tauri/src/engine/app_lists.rs
+++ b/v2/src-tauri/src/engine/app_lists.rs
@@ -8,13 +8,6 @@ use serde::{Deserialize, Serialize};
 use super::detection::DeviceType;
 use super::types::AppEntry;
 
-/// A named app list — one of common / shield / googletv (or any user/community add).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AppList {
-    pub name: String,
-    pub entries: Vec<AppEntry>,
-}
-
 /// All loaded app lists, indexed for lookup.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppListBundle {

--- a/v2/src-tauri/src/engine/mod.rs
+++ b/v2/src-tauri/src/engine/mod.rs
@@ -13,7 +13,7 @@ pub mod safety;
 pub mod snapshot;
 pub mod types;
 
-pub use app_lists::{AppList, AppListBundle};
+pub use app_lists::AppListBundle;
 pub use detection::{detect_device_type, DeviceType};
 pub use launcher::{
     is_last_enabled_home_handler, is_valid_package_name, launcher_catalog, launcher_rows,

--- a/v2/src-tauri/src/engine/types.rs
+++ b/v2/src-tauri/src/engine/types.rs
@@ -98,21 +98,6 @@ pub enum RiskTier {
     Advanced,
 }
 
-impl RiskTier {
-    /// Parse a risk-tier label permissively. Accepts v1's strings
-    /// ("Safe" / "Medium" / "High Risk" / "Advanced") case-insensitively.
-    /// Defaults to `Medium` for unrecognized strings — safer than `Safe`.
-    pub fn parse_label(s: &str) -> Self {
-        match s.to_ascii_lowercase().as_str() {
-            "safe" => Self::Safe,
-            "medium" => Self::Medium,
-            "advanced" => Self::Advanced,
-            "high" | "high risk" => Self::High,
-            _ => Self::Medium,
-        }
-    }
-}
-
 /// One entry in the bloat list — direct port of v1's app schema.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppEntry {

--- a/v2/src/lib/components/FilesTab.svelte
+++ b/v2/src/lib/components/FilesTab.svelte
@@ -545,7 +545,7 @@
     background: none;
     border: none;
     padding: 0;
-    color: var(--fg);
+    color: var(--fg-primary);
     cursor: pointer;
     font-size: 0.95rem;
   }

--- a/v2/src/lib/types.ts
+++ b/v2/src/lib/types.ts
@@ -357,7 +357,3 @@ export function deviceTypeLabel(t: DeviceType): string {
       return "Unknown";
   }
 }
-
-export function riskBadgeClass(r: RiskTier): string {
-  return `risk-${r}`;
-}

--- a/v2/src/routes/+page.svelte
+++ b/v2/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from "$app/navigation";
   import { onMount } from "svelte";
   import { api } from "$lib/api";
   import type { Device, DeviceReport } from "$lib/types";

--- a/v2/src/routes/devices/[serial]/+page.svelte
+++ b/v2/src/routes/devices/[serial]/+page.svelte
@@ -2026,9 +2026,6 @@
     margin: 0.4rem 0;
     padding-left: 1.2rem;
   }
-  .preview-disclaimer {
-    margin-top: 0 !important;
-  }
   .header-actions {
     display: flex;
     gap: 0.8rem;
@@ -2097,27 +2094,6 @@
   .small-action.subtle:hover:not(:disabled) {
     background: var(--bg-button);
     color: var(--fg-secondary);
-  }
-  .state-badge {
-    display: inline-block;
-    font-size: 0.74rem;
-    padding: 0.15rem 0.55rem;
-    border-radius: 4px;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    font-family: ui-monospace, monospace;
-  }
-  .state-badge.state-enabled {
-    background: var(--ok-surface);
-    color: var(--ok);
-  }
-  .state-badge.state-disabled {
-    background: var(--warn-surface-2);
-    color: var(--warn);
-  }
-  .state-badge.state-missing {
-    background: var(--bg-muted);
-    color: var(--fg-faint);
   }
   .action-message {
     margin-top: 0.4rem;
@@ -2294,14 +2270,6 @@
   }
   .type-cell { white-space: nowrap; }
   .type-cell .tag { white-space: nowrap; }
-  .checkbox-row {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-size: 0.85rem;
-    color: var(--fg-secondary);
-    cursor: pointer;
-  }
   .legend {
     display: flex;
     align-items: center;
@@ -2313,17 +2281,6 @@
     border: 1px solid var(--border);
     border-radius: 4px;
     line-height: 1.4;
-  }
-  .install-output {
-    background: var(--bg-inset);
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    padding: 0.7rem 1rem;
-    margin: 0.8rem 0;
-    font-family: ui-monospace, monospace;
-    font-size: 0.82rem;
-    white-space: pre-wrap;
-    word-break: break-word;
   }
   code {
     background: var(--bg-inset);


### PR DESCRIPTION
The audit's leftover hygiene items, deferred until the stack landed so nothing could conflict:

- **Rust**: unused `anyhow` dep; three uncalled `SubprocessAdb` methods (`from_path`/`binary`/`with_timeout` — superseded by `raw_transfer`); the never-used `AppList` struct; `RiskTier::parse_label`; `parse_dumpsys_meminfo` demoted to private behind its public alias.
- **Frontend**: `riskBadgeClass`, an unused `goto` import, four orphaned CSS blocks in the device page, and `.dir-link`'s undefined `--fg` token → `--fg-primary`.

Pure deletions plus one token fix. Validated: clippy `--all-targets -- -D warnings` clean, 149 tests, svelte-check 0/0, build green.