### PR TITLE
AppImage: strip bundled libwayland so the host's is used

### DIFF
--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -45,14 +45,21 @@ jobs:
             pacman -Q mesa wayland weston
           '
 
+      - name: Start headless weston (detached, survives exec sessions)
+        run: |
+          docker exec wayland-box bash -c \
+            'mkdir -p /tmp/xdg && chmod 700 /tmp/xdg'
+          docker exec -d wayland-box bash -c \
+            'XDG_RUNTIME_DIR=/tmp/xdg weston --backend=headless --socket=wayland-1 >/tmp/weston.log 2>&1'
+          sleep 4
+          docker exec wayland-box bash -c \
+            'ls -la /tmp/xdg/; head -5 /tmp/weston.log'
+          docker exec wayland-box test -S /tmp/xdg/wayland-1
+
       - name: "Run 1: unpatched AppImage (expect EGL failure)"
         run: |
           docker exec wayland-box bash -c '
             export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root
-            mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
-            weston --backend=headless-backend.so --socket=wayland-1 \
-              >/tmp/weston.log 2>&1 &
-            sleep 3
             export WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
             cp -r /unpatched /app
             timeout 20 /app/AppRun >/tmp/run.log 2>&1; echo "exit=$?"

--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -56,15 +56,28 @@ jobs:
             'ls -la /tmp/xdg/; head -5 /tmp/weston.log'
           docker exec wayland-box test -S /tmp/xdg/wayland-1
 
+      - name: "Control: host GTK app against the same compositor"
+        run: |
+          docker exec wayland-box bash -c '
+            pacman -S --noconfirm --needed gtk3-demos >/dev/null 2>&1 || true
+            export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root \
+                   WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
+            app=$(command -v gtk3-demo || command -v gtk3-widget-factory || echo none)
+            echo "control app: $app"
+            timeout 10 "$app" >/tmp/control.log 2>&1; echo "control exit=$?"
+            tail -3 /tmp/control.log
+          '
+
       - name: "Run 1: unpatched AppImage (expect EGL failure)"
         run: |
           docker exec wayland-box bash -c '
             export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root
             export WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
+            export G_MESSAGES_DEBUG=all
             cp -r /unpatched /app
             timeout 20 /app/AppRun >/tmp/run.log 2>&1; echo "exit=$?"
             echo "--- app output (unpatched):"
-            cat /tmp/run.log
+            cat /tmp/run.log | head -40
           ' | tee unpatched.log
 
       - name: "Run 2: libwayland stripped (the fix — expect clean boot)"

--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -54,7 +54,7 @@ jobs:
             'XDG_RUNTIME_DIR=/tmp/xdg weston --backend=headless --socket=wayland-1 --xwayland >/tmp/weston.log 2>&1'
           sleep 5
           docker exec wayland-box bash -c \
-            'ls -la /tmp/xdg/; grep -i xwayland /tmp/weston.log || head -8 /tmp/weston.log'
+            'ls -la /tmp/xdg/; echo "--- weston log:"; cat /tmp/weston.log'
           docker exec wayland-box test -S /tmp/xdg/wayland-1
 
       - name: "Control: host GTK app against the same compositor"

--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -1,27 +1,35 @@
-# One-off verification harness for issue #60 (AppImage blank window on
-# Wayland). Recreates the reporter's environment — bleeding-edge Arch
-# userspace (CachyOS is Arch-based) + a Wayland compositor — headlessly in a
-# container, then runs the SHIPPED beta.12 AppImage twice:
+# Verification harness for issue #60 (AppImage blank window on Wayland).
+# Recreates the affected environment — bleeding-edge Arch userspace (CachyOS
+# is Arch-based) + headless weston with XWayland (the AppRun GTK hook forces
+# GDK_BACKEND=x11, so that's what real Wayland desktops run the app under) —
+# then runs a released AppImage twice:
 #
-#   1. unpatched            → expect "Could not create default EGL display"
-#   2. libwayland stripped  → expect a clean boot (the PR's fix)
+#   1. as shipped           → a broken build hits "Could not create default
+#                             EGL display: EGL_BAD_PARAMETER"
+#   2. libwayland stripped  → must boot clean
 #
-# Delete this workflow once the fix is confirmed and released.
+# Verified 2026-06-11 against v2-2.0.0-beta.12: run 1 reproduced the
+# reporter's crash exactly; run 2 booted clean. Releases built after the
+# strip-libwayland step shipped should pass BOTH runs (nothing to strip).
 name: AppImage Wayland repro test
 
 on:
-  push:
-    branches: [fix/appimage-bundled-wayland]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag whose AppImage to test"
+        required: true
+        default: "v2-2.0.0-beta.12"
 
 jobs:
   repro:
     runs-on: ubuntu-latest
     steps:
-      - name: Download shipped beta.12 AppImage
+      - name: Download released AppImage
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download v2-2.0.0-beta.12 -R "$GITHUB_REPOSITORY" \
+          gh release download "${{ inputs.tag }}" -R "$GITHUB_REPOSITORY" \
             -p '*.AppImage' -O shield.AppImage
           chmod +x shield.AppImage
           # Extract on the host (no FUSE needed) and mount the tree into the

--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -38,22 +38,23 @@ jobs:
           docker exec wayland-box bash -c '
             pacman -Syu --noconfirm --needed \
               weston mesa wayland libxkbcommon fontconfig ttf-dejavu \
-              gtk3 webkit2gtk-4.1 dbus glibc >/dev/null 2>&1 || \
-            pacman -Syu --noconfirm --needed \
-              weston mesa wayland libxkbcommon fontconfig ttf-dejavu \
-              gtk3 dbus glibc >/dev/null
-            pacman -Q mesa wayland weston
+              gtk3 dbus glibc xorg-xwayland xkeyboard-config >/dev/null
+            pacman -Q mesa wayland weston xorg-xwayland
           '
 
-      - name: Start headless weston (detached, survives exec sessions)
+      # The AppImage's linuxdeploy GTK hook forces GDK_BACKEND=x11 (Tauri
+      # workaround for a GTK-Wayland crash), so on a real Wayland desktop the
+      # app runs under XWayland — recreate exactly that: headless weston WITH
+      # --xwayland, giving the app an X server backed by a Wayland compositor.
+      - name: Start headless weston + XWayland (detached)
         run: |
           docker exec wayland-box bash -c \
             'mkdir -p /tmp/xdg && chmod 700 /tmp/xdg'
           docker exec -d wayland-box bash -c \
-            'XDG_RUNTIME_DIR=/tmp/xdg weston --backend=headless --socket=wayland-1 >/tmp/weston.log 2>&1'
-          sleep 4
+            'XDG_RUNTIME_DIR=/tmp/xdg weston --backend=headless --socket=wayland-1 --xwayland >/tmp/weston.log 2>&1'
+          sleep 5
           docker exec wayland-box bash -c \
-            'ls -la /tmp/xdg/; head -5 /tmp/weston.log'
+            'ls -la /tmp/xdg/; grep -i xwayland /tmp/weston.log || head -8 /tmp/weston.log'
           docker exec wayland-box test -S /tmp/xdg/wayland-1
 
       - name: "Control: host GTK app against the same compositor"
@@ -72,8 +73,8 @@ jobs:
         run: |
           docker exec wayland-box bash -c '
             export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root
-            export WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
-            export G_MESSAGES_DEBUG=all
+            export WAYLAND_DISPLAY=wayland-1 DISPLAY=:0
+            # No GDK_BACKEND here — the AppRun hook forces x11 itself.
             cp -r /unpatched /app
             timeout 20 /app/AppRun >/tmp/run.log 2>&1; echo "exit=$?"
             echo "--- app output (unpatched):"
@@ -84,12 +85,12 @@ jobs:
         run: |
           docker exec wayland-box bash -c '
             export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root \
-                   WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
+                   WAYLAND_DISPLAY=wayland-1 DISPLAY=:0
             cp -r /unpatched /app-patched
             rm -v /app-patched/usr/lib/libwayland-*.so*
             timeout 20 /app-patched/AppRun >/tmp/run2.log 2>&1; echo "exit=$?"
             echo "--- app output (patched):"
-            cat /tmp/run2.log
+            cat /tmp/run2.log | head -40
           ' | tee patched.log
 
       - name: Verdict

--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -1,0 +1,97 @@
+# One-off verification harness for issue #60 (AppImage blank window on
+# Wayland). Recreates the reporter's environment — bleeding-edge Arch
+# userspace (CachyOS is Arch-based) + a Wayland compositor — headlessly in a
+# container, then runs the SHIPPED beta.12 AppImage twice:
+#
+#   1. unpatched            → expect "Could not create default EGL display"
+#   2. libwayland stripped  → expect a clean boot (the PR's fix)
+#
+# Delete this workflow once the fix is confirmed and released.
+name: AppImage Wayland repro test
+
+on:
+  push:
+    branches: [fix/appimage-bundled-wayland]
+
+jobs:
+  repro:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download shipped beta.12 AppImage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v2-2.0.0-beta.12 -R "$GITHUB_REPOSITORY" \
+            -p '*.AppImage' -O shield.AppImage
+          chmod +x shield.AppImage
+          # Extract on the host (no FUSE needed) and mount the tree into the
+          # container — sidesteps AppImage runtime/FUSE issues entirely.
+          ./shield.AppImage --appimage-extract >/dev/null
+          ls squashfs-root/usr/lib/ | grep wayland || true
+
+      - name: Prepare Arch container with headless Wayland
+        run: |
+          docker pull -q archlinux:latest
+          docker run -d --name wayland-box \
+            -v "$PWD/squashfs-root:/unpatched:ro" \
+            archlinux:latest sleep infinity
+          docker exec wayland-box bash -c '
+            pacman -Syu --noconfirm --needed \
+              weston mesa wayland libxkbcommon fontconfig ttf-dejavu \
+              gtk3 webkit2gtk-4.1 dbus glibc >/dev/null 2>&1 || \
+            pacman -Syu --noconfirm --needed \
+              weston mesa wayland libxkbcommon fontconfig ttf-dejavu \
+              gtk3 dbus glibc >/dev/null
+            pacman -Q mesa wayland weston
+          '
+
+      - name: "Run 1: unpatched AppImage (expect EGL failure)"
+        run: |
+          docker exec wayland-box bash -c '
+            export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root
+            mkdir -p "$XDG_RUNTIME_DIR" && chmod 700 "$XDG_RUNTIME_DIR"
+            weston --backend=headless-backend.so --socket=wayland-1 \
+              >/tmp/weston.log 2>&1 &
+            sleep 3
+            export WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
+            cp -r /unpatched /app
+            timeout 20 /app/AppRun >/tmp/run.log 2>&1; echo "exit=$?"
+            echo "--- app output (unpatched):"
+            cat /tmp/run.log
+          ' | tee unpatched.log
+
+      - name: "Run 2: libwayland stripped (the fix — expect clean boot)"
+        run: |
+          docker exec wayland-box bash -c '
+            export XDG_RUNTIME_DIR=/tmp/xdg HOME=/root \
+                   WAYLAND_DISPLAY=wayland-1 GDK_BACKEND=wayland
+            cp -r /unpatched /app-patched
+            rm -v /app-patched/usr/lib/libwayland-*.so*
+            timeout 20 /app-patched/AppRun >/tmp/run2.log 2>&1; echo "exit=$?"
+            echo "--- app output (patched):"
+            cat /tmp/run2.log
+          ' | tee patched.log
+
+      - name: Verdict
+        run: |
+          echo "==================== VERDICT ===================="
+          if grep -q "Could not create default EGL display" unpatched.log; then
+            echo "REPRO CONFIRMED: unpatched AppImage hits the EGL failure."
+            repro=yes
+          else
+            echo "NOTE: unpatched run did NOT reproduce the EGL failure in this env."
+            repro=no
+          fi
+          if grep -q "Could not create default EGL display" patched.log; then
+            echo "FIX FAILED: patched AppImage still hits the EGL failure."
+            exit 1
+          fi
+          # timeout(1) exits 124 when the process was still alive at the
+          # deadline — for a GUI app that's the success signal.
+          if grep -q "exit=124" patched.log; then
+            echo "FIX VERIFIED: patched AppImage boots and stays alive (no EGL error)."
+          else
+            echo "WARN: patched app exited early — check its output above."
+            grep -q "exit=124" unpatched.log || echo "(unpatched also exited early)"
+            [ "$repro" = yes ] && exit 1 || echo "inconclusive but no EGL error in patched run"
+          fi

--- a/.github/workflows/appimage-wayland-test.yml
+++ b/.github/workflows/appimage-wayland-test.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Start headless weston + XWayland (detached)
         run: |
           docker exec wayland-box bash -c \
-            'mkdir -p /tmp/xdg && chmod 700 /tmp/xdg'
+            'mkdir -p /tmp/xdg && chmod 700 /tmp/xdg && mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix'
           docker exec -d wayland-box bash -c \
             'XDG_RUNTIME_DIR=/tmp/xdg weston --backend=headless --socket=wayland-1 --xwayland >/tmp/weston.log 2>&1'
           sleep 5

--- a/.github/workflows/v2-release.yml
+++ b/.github/workflows/v2-release.yml
@@ -204,6 +204,45 @@ jobs:
           includeUpdaterJson: false
           args: ${{ matrix.args }}
 
+      # The AppImage bundles Ubuntu 22.04's libwayland-*, which shadows the
+      # host's copy and breaks EGL display creation on newer Wayland stacks
+      # ("Could not create default EGL display: EGL_BAD_PARAMETER" on
+      # CachyOS/Arch + KDE — issue #60; the reporter's LD_PRELOAD of the
+      # system libwayland-client confirmed the diagnosis). Upstream
+      # linuxdeploy excludes libwayland for exactly this reason; Tauri's
+      # bundler doesn't yet, so strip it here, repack, and replace the asset
+      # tauri-action already uploaded.
+      - name: Strip bundled libwayland from AppImage (issue #60)
+        if: matrix.os == 'ubuntu-22.04'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.notes.outputs.tag }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          appimages=(v2/src-tauri/target/release/bundle/appimage/*.AppImage)
+          [ ${#appimages[@]} -eq 1 ] || { echo "expected exactly one AppImage, found: ${appimages[*]}"; exit 1; }
+          appimage="${appimages[0]}"
+
+          curl -fsSL -o /tmp/appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+          echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /tmp/appimagetool" | sha256sum -c -
+          chmod +x /tmp/appimagetool
+
+          workdir=$(mktemp -d)
+          (cd "$workdir" && "$GITHUB_WORKSPACE/$appimage" --appimage-extract >/dev/null)
+          rm -v "$workdir"/squashfs-root/usr/lib/libwayland-*.so*
+
+          # --appimage-extract-and-run: the tool itself is an AppImage and the
+          # runner may lack FUSE.
+          ARCH=x86_64 /tmp/appimagetool --appimage-extract-and-run \
+            "$workdir/squashfs-root" "$appimage"
+
+          # Replace the unpatched asset tauri-action uploaded. GitHub turns
+          # spaces in filenames into dots, so the names match up.
+          gh release upload "$TAG" "$appimage" --clobber
+          echo "patched + re-uploaded: $appimage"
+
   # Bump the Homebrew tap (bryanroscoe/homebrew-shield-optimizer) to point at
   # the new universal macOS DMG. Runs after all three bundlers succeed so the
   # asset is guaranteed to be on the GitHub Release before we reference it.

--- a/.github/workflows/v2-release.yml
+++ b/.github/workflows/v2-release.yml
@@ -231,7 +231,15 @@ jobs:
 
           workdir=$(mktemp -d)
           (cd "$workdir" && "$GITHUB_WORKSPACE/$appimage" --appimage-extract >/dev/null)
-          rm -v "$workdir"/squashfs-root/usr/lib/libwayland-*.so*
+          # nullglob is on: if a future Tauri bundler stops bundling libwayland
+          # (upstream linuxdeploy already excludes it), this becomes a no-op
+          # skip instead of a failed release.
+          stale=("$workdir"/squashfs-root/usr/lib/libwayland-*.so*)
+          if [ ${#stale[@]} -eq 0 ]; then
+            echo "no bundled libwayland found — bundler fixed upstream; skipping repack"
+            exit 0
+          fi
+          rm -v "${stale[@]}"
 
           # --appimage-extract-and-run: the tool itself is an AppImage and the
           # runner may lack FUSE.


### PR DESCRIPTION
Reopened #60: the beta.12 env-var fix didn't help, and the reporter's evidence pointed at the real root cause — **the AppImage bundles Ubuntu 22.04's `libwayland-{client,cursor,egl,server}`**, which shadow the host's libraries on modern Wayland stacks (CachyOS/Arch + KDE) and break EGL display creation underneath WebKit. I verified by extracting the shipped beta.12 artifact (all four libs present), and the reporter's working `LD_PRELOAD` of the system libwayland-client is the same fix expressed at runtime.

This is a known linuxdeploy-era issue — upstream linuxdeploy now excludes libwayland by default; Tauri's bundler hasn't caught up. So the Linux release job now post-processes: extract the AppImage → drop `usr/lib/libwayland-*.so*` → repack with appimagetool **1.9.1 pinned by SHA-256** → `gh release upload --clobber` over the asset tauri-action published.

The beta.12 `WEBKIT_DISABLE_DMABUF_RENDERER` guard stays — it addresses a different, also-real failure mode (NVIDIA DMABUF crashes).

I've asked the reporter to confirm the fix locally (extract + delete the libs + run AppRun) before we cut the next release.