### PR TITLE
v2: Private DNS (DNS-over-TLS) in Tweaks

### DIFF
--- a/Shield-Optimizer.ps1
+++ b/Shield-Optimizer.ps1
@@ -3686,14 +3686,19 @@ function Set-PrivateDns ($Target) {
         0 { & $Script:AdbPath -s $Target shell "settings put global private_dns_mode off" | Out-Null; Write-Success "Private DNS off." }
         1 { & $Script:AdbPath -s $Target shell "settings put global private_dns_mode opportunistic" | Out-Null; Write-Success "Private DNS automatic." }
         2 {
-            $dnsHost = Read-Host "Hostname (e.g. dns.adguard.com)"
-            if (-not [string]::IsNullOrWhiteSpace($dnsHost)) {
-                & $Script:AdbPath -s $Target shell "settings put global private_dns_specifier $($dnsHost.Trim())" | Out-Null
+            $dnsHost = (Read-Host "Hostname (e.g. dns.adguard.com)").Trim()
+            if ([string]::IsNullOrWhiteSpace($dnsHost)) {
+                Write-Warn "No hostname entered; unchanged."
+            } elseif ($dnsHost -notmatch "^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)+$") {
+                # Validate before interpolating into adb shell — a bare hostname can't carry shell metacharacters.
+                Write-ErrorMsg "Invalid hostname format. Expected something like 'dns.adguard.com'."
+            } else {
+                & $Script:AdbPath -s $Target shell "settings put global private_dns_specifier $dnsHost" | Out-Null
                 & $Script:AdbPath -s $Target shell "settings put global private_dns_mode hostname" | Out-Null
                 # A bad/unreachable DoT host leaves the device with NO working DNS (Android won't fall back).
                 # Probe by resolving+pinging a name; revert to automatic if it's dead so we never strand the device.
-                # ponytail: "bytes from" means resolution worked. DoT validation can lag a few seconds, so retry
-                # before giving up — a single probe false-negatives a good host. Swap for a real DoT handshake check if that's not enough.
+                # "bytes from" means resolution worked. DoT validation can lag a few seconds, so retry before
+                # giving up — a single probe false-negatives a good host. Swap for a real DoT handshake check if that's not enough.
                 $resolved = $false
                 foreach ($attempt in 1..3) {
                     Start-Sleep -Seconds 2
@@ -3701,12 +3706,12 @@ function Set-PrivateDns ($Target) {
                     if ($probe -match "bytes from") { $resolved = $true; break }
                 }
                 if ($resolved) {
-                    Write-Success "Private DNS set to $($dnsHost.Trim()); resolution verified."
+                    Write-Success "Private DNS set to $dnsHost; resolution verified."
                 } else {
                     & $Script:AdbPath -s $Target shell "settings put global private_dns_mode opportunistic" | Out-Null
-                    Write-Warn "No DNS resolution via $($dnsHost.Trim()) — reverted to automatic to keep the device online. Check the hostname."
+                    Write-Warn "No DNS resolution via $dnsHost — reverted to automatic to keep the device online. Check the hostname."
                 }
-            } else { Write-Warn "No hostname entered; unchanged." }
+            }
         }
     }
     if ($sel -ne -1 -and $sel -ne 3) { Pause }
@@ -4076,7 +4081,7 @@ while ($true) {
                 "Return to Main Menu.",
                 "Exit Optimizer."
             )
-            # Shortcuts: O=Optimize, R=Restore, E=rEport, L=Launcher, I=Install APK, P=Profile, C=reCovery, S=Scaling, K=tweaKs, N=sNapshot, T=reboot, D=Disconnect, B=Back, Q=Quit
+            # Shortcuts: O=Optimize, R=Restore, E=rEport, L=Launcher, I=Install APK, P=Profile, C=reCovery, S=Scaling, K=tweaKs, Y=privacY DNS, N=sNapshot, T=reboot, D=Disconnect, B=Back, Q=Quit
             $actionShortcuts = @("O", "R", "E", "L", "I", "P", "C", "S", "K", "Y", "N", "T", "D", "B", "Q")
             $aSel = Read-Menu -Title "Action Menu: $($target.Name) ($deviceTypeName)" -Options $aOpts -Descriptions $aDescs -Shortcuts $actionShortcuts
 

--- a/v2/src-tauri/src/commands/tuning.rs
+++ b/v2/src-tauri/src/commands/tuning.rs
@@ -214,9 +214,199 @@ pub async fn set_display_scaling(
     })
 }
 
+#[derive(Serialize)]
+pub struct PrivateDnsState {
+    /// `off` / `opportunistic` / `hostname`, or None if unset.
+    pub mode: Option<String>,
+    /// The DoT hostname when mode is `hostname`.
+    pub hostname: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct PrivateDnsResult {
+    pub ok: bool,
+    pub message: String,
+    /// True when a custom hostname failed to resolve and we reverted to
+    /// automatic to keep the device online.
+    pub reverted: bool,
+}
+
+/// A DNS hostname safe to interpolate into a `settings put` shell command.
+/// Mirrors v1's regex (Set-PrivateDns): dot-separated labels of
+/// `[A-Za-z0-9-]`, no label starting/ending with `-`, at least two labels.
+/// Pure so it can be unit-tested; the value is still shell-quoted on use.
+fn is_valid_dns_hostname(host: &str) -> bool {
+    if host.is_empty() || host.len() > 253 {
+        return false;
+    }
+    let labels: Vec<&str> = host.split('.').collect();
+    if labels.len() < 2 {
+        return false;
+    }
+    labels.iter().all(|l| {
+        !l.is_empty()
+            && l.len() <= 63
+            && l.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+            && !l.starts_with('-')
+            && !l.ends_with('-')
+    })
+}
+
+/// `get_private_dns` — read the device's current Private DNS mode + hostname.
+#[tauri::command]
+pub async fn get_private_dns(
+    state: State<'_, AppState>,
+    serial: String,
+) -> Result<PrivateDnsState, String> {
+    let adb = state.adb_snapshot().await;
+    let out = adb
+        .shell(
+            &serial,
+            "settings get global private_dns_mode; settings get global private_dns_specifier",
+        )
+        .await
+        .map_err(|e| format!("settings get: {e}"))?;
+    let mut lines = out.stdout.lines().map(|s| {
+        let v = s.trim();
+        if v.is_empty() || v == "null" {
+            None
+        } else {
+            Some(v.to_string())
+        }
+    });
+    Ok(PrivateDnsState {
+        mode: lines.next().flatten(),
+        hostname: lines.next().flatten(),
+    })
+}
+
+/// `set_private_dns` — switch Private DNS (DNS-over-TLS) mode. For a custom
+/// hostname, validate it, apply it, then probe DNS resolution and revert to
+/// automatic if the host is dead — a bad DoT host otherwise strands the device
+/// with no working DNS (Android won't fall back). Mirrors v1's Set-PrivateDns.
+#[tauri::command]
+pub async fn set_private_dns(
+    state: State<'_, AppState>,
+    serial: String,
+    mode: String,
+    hostname: Option<String>,
+) -> Result<PrivateDnsResult, String> {
+    let adb = state.adb_snapshot().await;
+    match mode.as_str() {
+        "off" => {
+            adb.shell(&serial, "settings put global private_dns_mode off")
+                .await
+                .map_err(|e| format!("settings put: {e}"))?;
+            Ok(PrivateDnsResult {
+                ok: true,
+                message: "Private DNS off.".to_string(),
+                reverted: false,
+            })
+        }
+        "opportunistic" => {
+            adb.shell(
+                &serial,
+                "settings put global private_dns_mode opportunistic",
+            )
+            .await
+            .map_err(|e| format!("settings put: {e}"))?;
+            Ok(PrivateDnsResult {
+                ok: true,
+                message: "Private DNS set to automatic.".to_string(),
+                reverted: false,
+            })
+        }
+        "hostname" => {
+            let host = hostname.unwrap_or_default();
+            let host = host.trim();
+            if !is_valid_dns_hostname(host) {
+                return Ok(PrivateDnsResult {
+                    ok: false,
+                    message: format!(
+                        "Invalid hostname {host:?}. Expected something like 'dns.adguard.com'."
+                    ),
+                    reverted: false,
+                });
+            }
+            let set_cmd = format!(
+                "settings put global private_dns_specifier {}; \
+                 settings put global private_dns_mode hostname",
+                quote_shell_arg(host)
+            );
+            adb.shell(&serial, &set_cmd)
+                .await
+                .map_err(|e| format!("settings put: {e}"))?;
+
+            // Probe: a custom DoT host that can't be reached leaves the device
+            // with no DNS. Retry a few times (DoT validation lags a few seconds)
+            // before deciding it's dead.
+            let mut resolved = false;
+            for _ in 0..3 {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                if let Ok(out) = adb
+                    .shell(&serial, "ping -c1 -W3 connectivitycheck.gstatic.com")
+                    .await
+                {
+                    if out.combined().contains("bytes from") {
+                        resolved = true;
+                        break;
+                    }
+                }
+            }
+            if resolved {
+                Ok(PrivateDnsResult {
+                    ok: true,
+                    message: format!("Private DNS set to {host}; resolution verified."),
+                    reverted: false,
+                })
+            } else {
+                adb.shell(
+                    &serial,
+                    "settings put global private_dns_mode opportunistic",
+                )
+                .await
+                .map_err(|e| format!("settings put: {e}"))?;
+                Ok(PrivateDnsResult {
+                    ok: false,
+                    message: format!(
+                        "No DNS resolution via {host} — reverted to automatic to keep the device \
+                         online. Check the hostname."
+                    ),
+                    reverted: true,
+                })
+            }
+        }
+        other => Ok(PrivateDnsResult {
+            ok: false,
+            message: format!("unknown Private DNS mode: {other}"),
+            reverted: false,
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::build_setting_command;
+    use super::{build_setting_command, is_valid_dns_hostname};
+
+    #[test]
+    fn accepts_real_dot_hostnames() {
+        assert!(is_valid_dns_hostname("dns.adguard.com"));
+        assert!(is_valid_dns_hostname("one.one.one.one"));
+        assert!(is_valid_dns_hostname("abcd.dns.nextdns.io"));
+        assert!(is_valid_dns_hostname("a-b.example-host.net"));
+    }
+
+    #[test]
+    fn rejects_bad_or_unsafe_hostnames() {
+        assert!(!is_valid_dns_hostname("")); // empty
+        assert!(!is_valid_dns_hostname("localhost")); // no dot
+        assert!(!is_valid_dns_hostname("-bad.com")); // label starts with -
+        assert!(!is_valid_dns_hostname("bad-.com")); // label ends with -
+        assert!(!is_valid_dns_hostname("a..b")); // empty label
+        assert!(!is_valid_dns_hostname("dns.adguard.com; reboot")); // shell metachar
+        assert!(!is_valid_dns_hostname("a$(whoami).com")); // injection attempt
+        assert!(!is_valid_dns_hostname("space host.com")); // space
+    }
 
     #[test]
     fn builds_put_with_quoted_value() {

--- a/v2/src-tauri/src/lib.rs
+++ b/v2/src-tauri/src/lib.rs
@@ -128,6 +128,8 @@ pub fn run() {
             tuning::write_setting,
             tuning::set_display_scaling,
             tuning::get_display_scaling,
+            tuning::get_private_dns,
+            tuning::set_private_dns,
             optimize::prepare_optimize,
             optimize::apply_performance_settings,
             update::check_for_update,

--- a/v2/src/lib/api.ts
+++ b/v2/src/lib/api.ts
@@ -29,6 +29,8 @@ import type {
   OtherPackage,
   PerformanceProfile,
   PerformanceResult,
+  PrivateDnsResult,
+  PrivateDnsState,
   RebootMode,
   RebootResult,
   RecoveryResult,
@@ -182,6 +184,10 @@ export const api = {
     invoke<DisplayScaleResult>("set_display_scaling", { serial, preset }),
   getDisplayScaling: (serial: string) =>
     invoke<CurrentDisplayScaling>("get_display_scaling", { serial }),
+  getPrivateDns: (serial: string) =>
+    invoke<PrivateDnsState>("get_private_dns", { serial }),
+  setPrivateDns: (serial: string, mode: string, hostname: string | null = null) =>
+    invoke<PrivateDnsResult>("set_private_dns", { serial, mode, hostname }),
 
   prepareOptimize: (serial: string, deviceType: DeviceType, mode: OptimizeMode) =>
     invoke<OptimizePlan>("prepare_optimize", { serial, deviceType, mode }),

--- a/v2/src/lib/components/TweaksTab.svelte
+++ b/v2/src/lib/components/TweaksTab.svelte
@@ -6,6 +6,7 @@
     SettingNamespace,
     DisplayScalePreset,
     CurrentDisplayScaling,
+    PrivateDnsState,
   } from "$lib/types";
 
   let { serial }: { serial: string } = $props();
@@ -34,20 +35,29 @@
   let assistantState = $state<"granted" | "revoked" | "missing" | null>(null);
   let assistantBusy = $state(false);
 
+  // Private DNS (DNS-over-TLS) — off / opportunistic (automatic) / hostname.
+  let privateDns = $state<PrivateDnsState | null>(null);
+  let dnsHostInput = $state("");
+  let dnsBusy = $state(false);
+  let dnsMessage = $state("");
+
   async function loadTweaks() {
     tweaksLoading = true;
     tweaksErr = null;
     try {
-      const [t, s, states, perm] = await Promise.all([
+      const [t, s, states, perm, dns] = await Promise.all([
         api.getTweaks(serial),
         api.getDisplayScaling(serial).catch(() => null),
         api.packageStates(serial, [NETFLIX_HOOKS_PKG]).catch(() => null),
         api.appPermissionState(serial, ASSISTANT_PKG, ASSISTANT_PERM).catch(() => null),
+        api.getPrivateDns(serial).catch(() => null),
       ]);
       tweaks = t;
       currentDisplayScaling = s;
       netflixHooksState = states ? (states[NETFLIX_HOOKS_PKG] ?? null) : null;
       assistantState = perm ?? null;
+      privateDns = dns;
+      dnsHostInput = dns?.hostname ?? "";
     } catch (e) {
       tweaksErr = String(e);
     } finally {
@@ -86,6 +96,35 @@
     } finally {
       assistantBusy = false;
     }
+  }
+
+  // Apply a Private DNS mode. For a custom hostname the backend validates it,
+  // probes resolution, and reverts to automatic if the host is dead — so a bad
+  // entry can't strand the device offline.
+  async function applyPrivateDns(mode: "off" | "opportunistic" | "hostname") {
+    if (mode === "hostname" && !dnsHostInput.trim()) {
+      dnsMessage = "Enter a hostname first (e.g. dns.adguard.com).";
+      return;
+    }
+    dnsBusy = true;
+    dnsMessage = mode === "hostname" ? "Applying and verifying resolution…" : "";
+    try {
+      const r = await api.setPrivateDns(serial, mode, mode === "hostname" ? dnsHostInput.trim() : null);
+      dnsMessage = r.message;
+      privateDns = await api.getPrivateDns(serial);
+      dnsHostInput = privateDns?.hostname ?? dnsHostInput;
+    } catch (e) {
+      dnsMessage = `Private DNS: ${e}`;
+    } finally {
+      dnsBusy = false;
+    }
+  }
+
+  function dnsModeLabel(mode: string | null, hostname: string | null): string {
+    if (mode === "off") return "Off";
+    if (mode === "opportunistic") return "Automatic";
+    if (mode === "hostname") return hostname ? `Custom (${hostname})` : "Custom";
+    return "Unset";
   }
 
   // Human-readable "current value" for each tweak — raw setting values like
@@ -257,6 +296,54 @@
           >Off</button>
         </div>
       </div>
+    {/if}
+
+    {#if privateDns}
+      <h3>Private DNS (DNS-over-TLS)</h3>
+      <p class="muted small">
+        Encrypt DNS lookups. <strong>Automatic</strong> uses the network's DoT if
+        offered; <strong>Custom</strong> routes through a host you pick (AdGuard,
+        NextDNS, Cloudflare…). A bad custom host is auto-reverted to Automatic so
+        the device never loses DNS.
+      </p>
+      <div class="tweak-row">
+        <div>
+          <div class="current">Current: <strong>{dnsModeLabel(privateDns.mode, privateDns.hostname)}</strong></div>
+          <div class="muted small mono">private_dns_mode = {privateDns.mode ?? "unset"}</div>
+        </div>
+        <div class="row-actions">
+          <button
+            class="small-action"
+            class:active={privateDns.mode === "off"}
+            disabled={dnsBusy}
+            onclick={() => applyPrivateDns("off")}
+          >Off</button>
+          <button
+            class="small-action"
+            class:active={privateDns.mode === "opportunistic"}
+            disabled={dnsBusy}
+            onclick={() => applyPrivateDns("opportunistic")}
+          >Automatic</button>
+        </div>
+      </div>
+      <div class="dns-custom">
+        <input
+          type="text"
+          placeholder="dns.adguard.com"
+          bind:value={dnsHostInput}
+          disabled={dnsBusy}
+          onkeydown={(e) => e.key === "Enter" && applyPrivateDns("hostname")}
+        />
+        <button
+          class="small-action"
+          class:active={privateDns.mode === "hostname"}
+          disabled={dnsBusy}
+          onclick={() => applyPrivateDns("hostname")}
+        >Use custom</button>
+      </div>
+      {#if dnsMessage}
+        <p class="muted small mono action-message">{dnsMessage}</p>
+      {/if}
     {/if}
 
     <h3>HDMI-CEC</h3>
@@ -525,6 +612,18 @@
     background: var(--accent-strong);
     color: #fff;
     border-color: var(--accent);
+  }
+  .dns-custom {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .dns-custom input {
+    flex: 1;
+    min-width: 200px;
+    max-width: 320px;
   }
   .current {
     font-size: 0.85rem;

--- a/v2/src/lib/demo-mock.ts
+++ b/v2/src/lib/demo-mock.ts
@@ -264,6 +264,10 @@ function handle(cmd: string, args: Record<string, unknown>): unknown {
       return demoFiles(args.path as string);
     case "get_display_scaling":
       return { size: "1920x1080 (default)", density: "320 (default)" };
+    case "get_private_dns":
+      return { mode: "opportunistic", hostname: null };
+    case "set_private_dns":
+      return { ok: true, message: "Private DNS updated.", reverted: false };
     case "list_snapshots":
       return snapshots;
     case "snapshot_dir_path":

--- a/v2/src/lib/types.ts
+++ b/v2/src/lib/types.ts
@@ -243,6 +243,17 @@ export interface InstallResult {
   message: string;
 }
 
+export interface PrivateDnsState {
+  mode: string | null;
+  hostname: string | null;
+}
+
+export interface PrivateDnsResult {
+  ok: boolean;
+  message: string;
+  reverted: boolean;
+}
+
 export interface SnapshotApplyPlan {
   packages_to_disable: string[];
   packages_already_disabled: string[];


### PR DESCRIPTION
Private DNS was added to v1 in #76 but never existed in v2. This ports it.

- **Tweaks tab**: Off / Automatic / Custom hostname.
- **Safety revert** (from v1): a custom DoT host that fails to resolve is probed (ping, 3 retries) and reverted to automatic, so a bad entry can't strand the device with no DNS.
- **Hostname validation** is a pure, unit-tested function; the value is also shell-quoted on use.
- Demo-mock fixture added so the Tweaks screen still renders offline.