### PR TITLE
Enable updater artifacts so auto-update manifest publishes

### DIFF
--- a/v2/src-tauri/tauri.conf.json
+++ b/v2/src-tauri/tauri.conf.json
@@ -33,6 +33,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "category": "Utility",
     "copyright": "Bryan Roscoe",


### PR DESCRIPTION
The beta.14 release's `Publish updater manifest` job failed: `latest.json not found on release`. Tauri 2 only emits signed updater artifacts (and the `latest.json` that tauri-action's `includeUpdaterJson` uploads) when `bundle.createUpdaterArtifacts` is `true`. That flag was missing.

This enables it so the next release produces the artifacts and publishes the updater manifest, which is what makes in-app auto-update actually work.