### PR TITLE
Default auto-update to off (opt-in)

### DIFF
--- a/v2/src/lib/prefs.ts
+++ b/v2/src/lib/prefs.ts
@@ -1,8 +1,11 @@
 const KEY = "shieldopt.autoUpdate";
 
+// Opt-in: off unless the user explicitly enables it. The build is unsigned, so
+// silently downloading + installing a new version on launch (possibly mid-task)
+// is surprising — the update is still surfaced via the badge / "Update now".
 export function getAutoUpdate(): boolean {
-  if (typeof localStorage === "undefined") return true;
-  return localStorage.getItem(KEY) !== "false";
+  if (typeof localStorage === "undefined") return false;
+  return localStorage.getItem(KEY) === "true";
 }
 
 export function setAutoUpdate(enabled: boolean): void {


### PR DESCRIPTION
Auto-update defaulted to on. For an unsigned app, silently downloading + installing a new version on launch (possibly mid-task on a device) is surprising. This flips the default to off — opt-in via the header checkbox. Updates are still surfaced by the version badge and the "Update now" button; nothing is installed without consent.