### PR TITLE
Updater: 'Restart now' button after an update installs

### DIFF
--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "shield-optimizer-v2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shield-optimizer-v2",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.1"
       },
       "devDependencies": {
@@ -1228,6 +1229,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-updater": {

--- a/v2/package.json
+++ b/v2/package.json
@@ -17,6 +17,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {

--- a/v2/src-tauri/Cargo.lock
+++ b/v2/src-tauri/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-updater",
  "tempfile",
  "thiserror 1.0.69",
@@ -4180,6 +4181,16 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
 ]
 
 [[package]]

--- a/v2/src-tauri/Cargo.toml
+++ b/v2/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/v2/src-tauri/capabilities/default.json
+++ b/v2/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "dialog:allow-open",
-    "updater:default"
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/v2/src-tauri/src/lib.rs
+++ b/v2/src-tauri/src/lib.rs
@@ -67,6 +67,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(state)
         .invoke_handler(tauri::generate_handler![
             devices::list_devices,

--- a/v2/src/routes/+layout.svelte
+++ b/v2/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import { page } from "$app/stores";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import { check, type Update } from "@tauri-apps/plugin-updater";
+  import { relaunch } from "@tauri-apps/plugin-process";
   import { getThemePref, setThemePref, type ThemePref } from "$lib/theme";
   import { getAutoUpdate, setAutoUpdate } from "$lib/prefs";
   import { api } from "$lib/api";
@@ -15,6 +16,7 @@
   let update = $state<UpdateInfo | null>(null);
   let pendingUpdate = $state<Update | null>(null);
   let updateBusy = $state(false);
+  let updateInstalled = $state(false);
   let updateProgress = $state("");
 
   onMount(() => {
@@ -55,10 +57,21 @@
           updateProgress = "Installing…";
         }
       });
-      updateProgress = "Update installed — restart the app to apply.";
+      updateInstalled = true;
+      updateBusy = false;
     } catch (e) {
       updateProgress = `Update failed: ${e}`;
       updateBusy = false;
+    }
+  }
+
+  async function restartApp() {
+    try {
+      await relaunch();
+    } catch (e) {
+      updateProgress = `Couldn't restart automatically (${e}) — quit and reopen to finish updating.`;
+      updateInstalled = false;
+      updateBusy = true;
     }
   }
 
@@ -87,7 +100,11 @@
       {#if update}
         <span class="version" title="Installed version">v{update.current}</span>
         {#if pendingUpdate}
-          {#if updateBusy}
+          {#if updateInstalled}
+            <button class="update-badge installed" onclick={restartApp} title="Relaunch to finish updating">
+              Update installed — Restart now ↻
+            </button>
+          {:else if updateBusy}
             <span class="update-badge updating">{updateProgress}</span>
           {:else}
             <button class="update-badge" onclick={installUpdate} title="Download and install now">
@@ -370,6 +387,13 @@
   .update-badge.updating {
     cursor: default;
     opacity: 0.8;
+  }
+  .update-badge.installed {
+    background: var(--accent);
+    color: #fff;
+  }
+  .update-badge.installed:hover {
+    background: var(--accent-strong-hover);
   }
   .header-right {
     display: flex;


### PR DESCRIPTION
After an update downloads + installs, the header badge showed **'Update installed — restart the app to apply.'** as static text — leaving the user to figure out they had to quit and reopen.

Now it's a **'Update installed — Restart now ↻'** button that relaunches the app in one click via Tauri's process plugin, finishing the update.

- Adds `tauri-plugin-process` (Rust) + `@tauri-apps/plugin-process` (JS), registered in `lib.rs`, with the `process:allow-restart` capability.
- Restart button styled as a filled accent CTA so it reads as actionable.
- If `relaunch()` fails, falls back to a clear 'quit and reopen manually' message.

This is the in-app half of the macOS update story; the bundle-swap itself still needs the app to not be quarantine-translocated (separate, signing-related limitation). No screenshot regen — the post-install state only appears after a real update, which the demo fixture never triggers.

cargo fmt/clippy/build green; npm run check 0/0; build green.